### PR TITLE
Bootstrap project with default files

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,0 +1,36 @@
+local image = 'grafana/build-container:1.2.27';
+
+local pipeline(name, trigger) = {
+  kind: 'pipeline',
+  type: 'docker',
+  name: name,
+  platform: {
+    os: 'linux',
+    arch: 'amd64',
+  },
+  trigger: trigger,
+  steps: [
+    {
+      name: 'test',
+      image: image,
+      commands: [
+        'make test',
+      ],
+    },
+  ],
+};
+
+[
+  pipeline('test-pr', {
+    event: [
+      'pull_request',
+    ],
+  }),
+
+  pipeline('test-master', {
+    branch: 'master',
+    event: [
+      'push',
+    ],
+  }),
+]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,0 +1,45 @@
+---
+kind: pipeline
+type: docker
+name: test-pr
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: grafana/build-container:1.2.27
+  commands:
+  - make test
+
+trigger:
+  event:
+  - pull_request
+
+---
+kind: pipeline
+type: docker
+name: test-master
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test
+  image: grafana/build-container:1.2.27
+  commands:
+  - make test
+
+trigger:
+  branch:
+  - master
+  event:
+  - push
+
+---
+kind: signature
+hmac: 4b9e92aa0df11523a1df89ec418113152fa135a012967f3c9e11a9fbc27a7dea
+
+...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+[*.go]
+indent_style = tab
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem?**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,23 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: 'New Features'
+    label: 'new feature'
+  - title: 'Bug Fixes'
+    label: 'fix'
+  - title: 'Improvements'
+    label: 'enhancement'
+version-resolver:
+  major:
+    labels:
+      - 'breaking change'
+  minor:
+    labels:
+      - 'new feature'
+  default: patch
+template: |
+  # Changelog
+  
+  $CHANGES
+
+  Changes since previous release: https://github.com/grafana/grafana-openapi-client-go/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# vim swap files
+.*.sw?
+.idea

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,83 @@
+[run]
+timeout = "10m"
+
+[linters-settings.golint]
+min-confidence = 3
+
+[linters-settings.goconst]
+min-len = 5
+min-occurrences = 5
+
+[linters]
+disable-all = true
+enable = [
+  "bodyclose",
+  "deadcode",
+  "depguard",
+  "dogsled",
+  "errcheck",
+  "gochecknoinits",
+  "goconst",
+  "gocritic",
+  "goimports",
+  "golint",
+  "goprintffuncname",
+  "gosec",
+  "gosimple",
+  "govet",
+  "ineffassign",
+  "misspell",
+  "nakedret",
+  "rowserrcheck",
+  "exportloopref",
+  "staticcheck",
+  "structcheck",
+  "stylecheck",
+  "typecheck",
+  "unconvert",
+  "unused",
+  "varcheck",
+  "whitespace",
+  "gocyclo",
+  "unparam",
+]
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G108"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G110"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G201"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G202"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G306"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "401"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "402"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "501"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "404"
+
+[[issues.exclude-rules]]
+linters = ["misspell"]
+text = "Unknwon` is a misspelling of `Unknown"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: drone, test
+
+drone:
+	drone jsonnet --stream --format --source .drone/drone.jsonnet --target .drone/drone.yml
+	drone lint .drone/drone.yml
+	drone sign --save grafana/grafana-openapi-client-go .drone/drone.yml
+
+test:
+	go version
+	golangci-lint --version
+	golangci-lint run ./...
+	go test -cover -race -vet all -mod readonly ./...

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Grafana HTTP OpenAPI Client for Go
+
+> :warning: Grafana's OpenAPI Go client is currently under construction. Progress is tracked [here](https://github.com/grafana/grafana/issues/47827).
+
+This HTTP Go client for [Grafana](https://github.com/grafana/grafana) is generated from [Grafana's OpenAPI specification](https://github.com/grafana/grafana/blob/main/public/api-merged.json) using [go-swagger](https://github.com/go-swagger/go-swagger).


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/71995

This PR adds a basic README and templates for Drone CI, Makefile, GitHub issues files, linting, etc.

The files are the ones in the existing client https://github.com/grafana/grafana-api-golang-client, updated where necessary.