### PR TITLE
Remove WithTransport from clientFacade

### DIFF
--- a/client/grafana_http_api_client.go
+++ b/client/grafana_http_api_client.go
@@ -340,14 +340,6 @@ func (c *GrafanaHTTPAPI) SetTransport(transport runtime.ClientTransport) {
 	c.Users.SetTransport(transport)
 }
 
-// WithTransport changes the transport on the client and all its subresources
-// and returns the client
-func (c *GrafanaHTTPAPI) WithTransport(transport runtime.ClientTransport) *GrafanaHTTPAPI {
-	c.Transport = transport
-	c.Folders.SetTransport(transport)
-	return c
-}
-
 // OrgID returns the organization ID that was set in the transport config
 func (c *GrafanaHTTPAPI) OrgID() int64 {
 	return c.cfg.OrgID
@@ -356,7 +348,8 @@ func (c *GrafanaHTTPAPI) OrgID() int64 {
 // WithOrgID sets the organization ID and returns the client
 func (c *GrafanaHTTPAPI) WithOrgID(orgID int64) *GrafanaHTTPAPI {
 	c.cfg.OrgID = orgID
-	return c.WithTransport(newTransportWithConfig(c.cfg))
+	c.SetTransport(newTransportWithConfig(c.cfg))
+	return c
 }
 
 func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {

--- a/templates/clientFacade.gotmpl
+++ b/templates/clientFacade.gotmpl
@@ -148,14 +148,6 @@ func (c *{{pascalize .Name}}) SetTransport(transport runtime.ClientTransport) {
   {{- end }}
 }
 
-// WithTransport changes the transport on the client and all its subresources
-// and returns the client
-func (c *{{pascalize .Name}}) WithTransport(transport runtime.ClientTransport) *{{pascalize .Name}} {
-	c.Transport = transport
-	c.Folders.SetTransport(transport)
-	return c
-}
-
 // OrgID returns the organization ID that was set in the transport config
 func (c *{{pascalize .Name}}) OrgID() int64 {
   return c.cfg.OrgID
@@ -164,7 +156,8 @@ func (c *{{pascalize .Name}}) OrgID() int64 {
 // WithOrgID sets the organization ID and returns the client
 func (c *{{pascalize .Name}}) WithOrgID(orgID int64) *{{pascalize .Name}} {
   c.cfg.OrgID = orgID
-	return c.WithTransport(newTransportWithConfig(c.cfg))
+  c.SetTransport(newTransportWithConfig(c.cfg))
+  return c
 }
 
 func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {


### PR DESCRIPTION
Resolves @mbarrien's [feedback](https://github.com/grafana/grafana-openapi-client-go/pull/13#pullrequestreview-1679687728).

* Remove WithTransport from templates/clientFacade since it adds to the complexity of generating the client. Instead, use SetTransport and return the client.