### PR TITLE
feat: Add optional HTTP headers map to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ cfg := &goapi.TransportConfig{
     RetryTimeout: 0,
     // RetryStatusCodes contains the optional list of status codes to retry
     // Use "x" as a wildcard for a single digit (default: [429, 5xx])
-    RetryStatusCodes []string{"420, 5xx"},
+    RetryStatusCodes: []string{"420, 5xx"},
+    // HTTPHeaders contains an optional map of HTTP headers to add to each request
+    HTTPHeaders: map[string]string{},
 }
 
 client := goapi.NewHTTPClientWithConfig(strfmt.Default, cfg)

--- a/client/grafana_http_api_client.go
+++ b/client/grafana_http_api_client.go
@@ -191,6 +191,8 @@ type TransportConfig struct {
 	// RetryStatusCodes contains the optional list of status codes to retry
 	// Use "x" as a wildcard for a single digit (default: [429, 5xx])
 	RetryStatusCodes []string
+	// HttpHeaders contains an optional map of HTTP headers to add to each request
+	HttpHeaders map[string]string
 }
 
 // WithHost overrides the default host,
@@ -373,6 +375,7 @@ func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
 		NumRetries:       cfg.NumRetries,
 		RetryTimeout:     cfg.RetryTimeout,
 		RetryStatusCodes: cfg.RetryStatusCodes,
+		HttpHeaders:      cfg.HttpHeaders,
 	}
 
 	tr := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)

--- a/client/grafana_http_api_client.go
+++ b/client/grafana_http_api_client.go
@@ -191,8 +191,8 @@ type TransportConfig struct {
 	// RetryStatusCodes contains the optional list of status codes to retry
 	// Use "x" as a wildcard for a single digit (default: [429, 5xx])
 	RetryStatusCodes []string
-	// HttpHeaders contains an optional map of HTTP headers to add to each request
-	HttpHeaders map[string]string
+	// HTTPHeaders contains an optional map of HTTP headers to add to each request
+	HTTPHeaders map[string]string
 }
 
 // WithHost overrides the default host,
@@ -375,7 +375,7 @@ func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
 		NumRetries:       cfg.NumRetries,
 		RetryTimeout:     cfg.RetryTimeout,
 		RetryStatusCodes: cfg.RetryStatusCodes,
-		HttpHeaders:      cfg.HttpHeaders,
+		HTTPHeaders:      cfg.HTTPHeaders,
 	}
 
 	tr := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)

--- a/models/route.go
+++ b/models/route.go
@@ -72,6 +72,10 @@ func (m *Route) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateObjectMatchers(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateProvenance(formats); err != nil {
 		res = append(res, err)
 	}
@@ -115,6 +119,23 @@ func (m *Route) validateMatchers(formats strfmt.Registry) error {
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *Route) validateObjectMatchers(formats strfmt.Registry) error {
+	if swag.IsZero(m.ObjectMatchers) { // not required
+		return nil
+	}
+
+	if err := m.ObjectMatchers.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("object_matchers")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}
@@ -177,6 +198,10 @@ func (m *Route) ContextValidate(ctx context.Context, formats strfmt.Registry) er
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateObjectMatchers(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateProvenance(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -216,6 +241,20 @@ func (m *Route) contextValidateMatchers(ctx context.Context, formats strfmt.Regi
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *Route) contextValidateObjectMatchers(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.ObjectMatchers.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("object_matchers")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -19,9 +19,14 @@ type RetryableTransport struct {
 	NumRetries       int
 	RetryTimeout     time.Duration
 	RetryStatusCodes []string
+	HttpHeaders      map[string]string
 }
 
 func (t *RetryableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, v := range t.HttpHeaders {
+		req.Header.Set(k, v)
+	}
+
 	var (
 		resp             *http.Response
 		err              error

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -19,11 +19,11 @@ type RetryableTransport struct {
 	NumRetries       int
 	RetryTimeout     time.Duration
 	RetryStatusCodes []string
-	HttpHeaders      map[string]string
+	HTTPHeaders      map[string]string
 }
 
 func (t *RetryableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	for k, v := range t.HttpHeaders {
+	for k, v := range t.HTTPHeaders {
 		req.Header.Set(k, v)
 	}
 

--- a/templates/clientFacade.gotmpl
+++ b/templates/clientFacade.gotmpl
@@ -117,8 +117,8 @@ type TransportConfig struct {
     // RetryStatusCodes contains the optional list of status codes to retry
     // Use "x" as a wildcard for a single digit (default: [429, 5xx])
     RetryStatusCodes []string
-    // HttpHeaders contains an optional map of HTTP headers to add to each request
-    HttpHeaders map[string]string
+    // HTTPHeaders contains an optional map of HTTP headers to add to each request
+    HTTPHeaders map[string]string
 }
 
 // WithHost overrides the default host,
@@ -181,7 +181,7 @@ func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
     NumRetries: cfg.NumRetries,
     RetryTimeout: cfg.RetryTimeout,
     RetryStatusCodes: cfg.RetryStatusCodes,
-    HttpHeaders: cfg.HttpHeaders,
+    HTTPHeaders: cfg.HTTPHeaders,
 	}
 
 	tr := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)	

--- a/templates/clientFacade.gotmpl
+++ b/templates/clientFacade.gotmpl
@@ -117,6 +117,8 @@ type TransportConfig struct {
     // RetryStatusCodes contains the optional list of status codes to retry
     // Use "x" as a wildcard for a single digit (default: [429, 5xx])
     RetryStatusCodes []string
+    // HttpHeaders contains an optional map of HTTP headers to add to each request
+    HttpHeaders map[string]string
 }
 
 // WithHost overrides the default host,
@@ -179,6 +181,7 @@ func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
     NumRetries: cfg.NumRetries,
     RetryTimeout: cfg.RetryTimeout,
     RetryStatusCodes: cfg.RetryStatusCodes,
+    HttpHeaders: cfg.HttpHeaders,
 	}
 
 	tr := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)	


### PR DESCRIPTION
This is a feature of the current client.
It can, for example, allow users to bypass proxies in front of their Grafana instance