### PR TITLE
Remove redundant `/api` prefix in alerting APIs

### DIFF
--- a/client/provisioning/delete_alert_rule_responses.go
+++ b/client/provisioning/delete_alert_rule_responses.go
@@ -27,7 +27,7 @@ func (o *DeleteAlertRuleReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[DELETE /api/v1/provisioning/alert-rules/{UID}] DeleteAlertRule", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /v1/provisioning/alert-rules/{UID}] DeleteAlertRule", response, response.Code())
 	}
 }
 
@@ -75,11 +75,11 @@ func (o *DeleteAlertRuleNoContent) Code() int {
 }
 
 func (o *DeleteAlertRuleNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/alert-rules/{UID}][%d] deleteAlertRuleNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/alert-rules/{UID}][%d] deleteAlertRuleNoContent ", 204)
 }
 
 func (o *DeleteAlertRuleNoContent) String() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/alert-rules/{UID}][%d] deleteAlertRuleNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/alert-rules/{UID}][%d] deleteAlertRuleNoContent ", 204)
 }
 
 func (o *DeleteAlertRuleNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/delete_contactpoints_responses.go
+++ b/client/provisioning/delete_contactpoints_responses.go
@@ -27,7 +27,7 @@ func (o *DeleteContactpointsReader) ReadResponse(response runtime.ClientResponse
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[DELETE /api/v1/provisioning/contact-points/{UID}] DeleteContactpoints", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /v1/provisioning/contact-points/{UID}] DeleteContactpoints", response, response.Code())
 	}
 }
 
@@ -75,11 +75,11 @@ func (o *DeleteContactpointsNoContent) Code() int {
 }
 
 func (o *DeleteContactpointsNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/contact-points/{UID}][%d] deleteContactpointsNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/contact-points/{UID}][%d] deleteContactpointsNoContent ", 204)
 }
 
 func (o *DeleteContactpointsNoContent) String() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/contact-points/{UID}][%d] deleteContactpointsNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/contact-points/{UID}][%d] deleteContactpointsNoContent ", 204)
 }
 
 func (o *DeleteContactpointsNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/delete_mute_timing_responses.go
+++ b/client/provisioning/delete_mute_timing_responses.go
@@ -27,7 +27,7 @@ func (o *DeleteMuteTimingReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[DELETE /api/v1/provisioning/mute-timings/{name}] DeleteMuteTiming", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /v1/provisioning/mute-timings/{name}] DeleteMuteTiming", response, response.Code())
 	}
 }
 
@@ -75,11 +75,11 @@ func (o *DeleteMuteTimingNoContent) Code() int {
 }
 
 func (o *DeleteMuteTimingNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/mute-timings/{name}][%d] deleteMuteTimingNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/mute-timings/{name}][%d] deleteMuteTimingNoContent ", 204)
 }
 
 func (o *DeleteMuteTimingNoContent) String() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/mute-timings/{name}][%d] deleteMuteTimingNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/mute-timings/{name}][%d] deleteMuteTimingNoContent ", 204)
 }
 
 func (o *DeleteMuteTimingNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/delete_template_responses.go
+++ b/client/provisioning/delete_template_responses.go
@@ -27,7 +27,7 @@ func (o *DeleteTemplateReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[DELETE /api/v1/provisioning/templates/{name}] DeleteTemplate", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /v1/provisioning/templates/{name}] DeleteTemplate", response, response.Code())
 	}
 }
 
@@ -75,11 +75,11 @@ func (o *DeleteTemplateNoContent) Code() int {
 }
 
 func (o *DeleteTemplateNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/templates/{name}][%d] deleteTemplateNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/templates/{name}][%d] deleteTemplateNoContent ", 204)
 }
 
 func (o *DeleteTemplateNoContent) String() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/templates/{name}][%d] deleteTemplateNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/provisioning/templates/{name}][%d] deleteTemplateNoContent ", 204)
 }
 
 func (o *DeleteTemplateNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_alert_rule_export_responses.go
+++ b/client/provisioning/get_alert_rule_export_responses.go
@@ -36,7 +36,7 @@ func (o *GetAlertRuleExportReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/alert-rules/{UID}/export] GetAlertRuleExport", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/alert-rules/{UID}/export] GetAlertRuleExport", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetAlertRuleExportOK) Code() int {
 }
 
 func (o *GetAlertRuleExportOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleExportOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleExportOK) GetPayload() *models.AlertingFileExport {
@@ -152,11 +152,11 @@ func (o *GetAlertRuleExportNotFound) Code() int {
 }
 
 func (o *GetAlertRuleExportNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportNotFound ", 404)
 }
 
 func (o *GetAlertRuleExportNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}/export][%d] getAlertRuleExportNotFound ", 404)
 }
 
 func (o *GetAlertRuleExportNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_alert_rule_group_export_responses.go
+++ b/client/provisioning/get_alert_rule_group_export_responses.go
@@ -36,7 +36,7 @@ func (o *GetAlertRuleGroupExportReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export] GetAlertRuleGroupExport", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export] GetAlertRuleGroupExport", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetAlertRuleGroupExportOK) Code() int {
 }
 
 func (o *GetAlertRuleGroupExportOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleGroupExportOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleGroupExportOK) GetPayload() *models.AlertingFileExport {
@@ -152,11 +152,11 @@ func (o *GetAlertRuleGroupExportNotFound) Code() int {
 }
 
 func (o *GetAlertRuleGroupExportNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportNotFound ", 404)
 }
 
 func (o *GetAlertRuleGroupExportNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export][%d] getAlertRuleGroupExportNotFound ", 404)
 }
 
 func (o *GetAlertRuleGroupExportNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_alert_rule_group_responses.go
+++ b/client/provisioning/get_alert_rule_group_responses.go
@@ -36,7 +36,7 @@ func (o *GetAlertRuleGroupReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}] GetAlertRuleGroup", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}] GetAlertRuleGroup", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetAlertRuleGroupOK) Code() int {
 }
 
 func (o *GetAlertRuleGroupOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleGroupOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleGroupOK) GetPayload() *models.AlertRuleGroup {
@@ -152,11 +152,11 @@ func (o *GetAlertRuleGroupNotFound) Code() int {
 }
 
 func (o *GetAlertRuleGroupNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupNotFound ", 404)
 }
 
 func (o *GetAlertRuleGroupNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] getAlertRuleGroupNotFound ", 404)
 }
 
 func (o *GetAlertRuleGroupNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_alert_rule_responses.go
+++ b/client/provisioning/get_alert_rule_responses.go
@@ -36,7 +36,7 @@ func (o *GetAlertRuleReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/alert-rules/{UID}] GetAlertRule", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/alert-rules/{UID}] GetAlertRule", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetAlertRuleOK) Code() int {
 }
 
 func (o *GetAlertRuleOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}][%d] getAlertRuleOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}][%d] getAlertRuleOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}][%d] getAlertRuleOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}][%d] getAlertRuleOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRuleOK) GetPayload() *models.ProvisionedAlertRule {
@@ -152,11 +152,11 @@ func (o *GetAlertRuleNotFound) Code() int {
 }
 
 func (o *GetAlertRuleNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}][%d] getAlertRuleNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}][%d] getAlertRuleNotFound ", 404)
 }
 
 func (o *GetAlertRuleNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/{UID}][%d] getAlertRuleNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/{UID}][%d] getAlertRuleNotFound ", 404)
 }
 
 func (o *GetAlertRuleNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_alert_rules_export_responses.go
+++ b/client/provisioning/get_alert_rules_export_responses.go
@@ -36,7 +36,7 @@ func (o *GetAlertRulesExportReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/alert-rules/export] GetAlertRulesExport", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/alert-rules/export] GetAlertRulesExport", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetAlertRulesExportOK) Code() int {
 }
 
 func (o *GetAlertRulesExportOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/export][%d] getAlertRulesExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/export][%d] getAlertRulesExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRulesExportOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/export][%d] getAlertRulesExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/export][%d] getAlertRulesExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRulesExportOK) GetPayload() *models.AlertingFileExport {
@@ -152,11 +152,11 @@ func (o *GetAlertRulesExportNotFound) Code() int {
 }
 
 func (o *GetAlertRulesExportNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/export][%d] getAlertRulesExportNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/export][%d] getAlertRulesExportNotFound ", 404)
 }
 
 func (o *GetAlertRulesExportNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules/export][%d] getAlertRulesExportNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules/export][%d] getAlertRulesExportNotFound ", 404)
 }
 
 func (o *GetAlertRulesExportNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_alert_rules_responses.go
+++ b/client/provisioning/get_alert_rules_responses.go
@@ -30,7 +30,7 @@ func (o *GetAlertRulesReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/alert-rules] GetAlertRules", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/alert-rules] GetAlertRules", response, response.Code())
 	}
 }
 
@@ -79,11 +79,11 @@ func (o *GetAlertRulesOK) Code() int {
 }
 
 func (o *GetAlertRulesOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules][%d] getAlertRulesOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules][%d] getAlertRulesOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRulesOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/alert-rules][%d] getAlertRulesOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/alert-rules][%d] getAlertRulesOk  %+v", 200, o.Payload)
 }
 
 func (o *GetAlertRulesOK) GetPayload() models.ProvisionedAlertRules {

--- a/client/provisioning/get_contactpoints_export_responses.go
+++ b/client/provisioning/get_contactpoints_export_responses.go
@@ -36,7 +36,7 @@ func (o *GetContactpointsExportReader) ReadResponse(response runtime.ClientRespo
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/contact-points/export] GetContactpointsExport", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/contact-points/export] GetContactpointsExport", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetContactpointsExportOK) Code() int {
 }
 
 func (o *GetContactpointsExportOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/contact-points/export][%d] getContactpointsExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/contact-points/export][%d] getContactpointsExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetContactpointsExportOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/contact-points/export][%d] getContactpointsExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/contact-points/export][%d] getContactpointsExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetContactpointsExportOK) GetPayload() *models.AlertingFileExport {
@@ -153,11 +153,11 @@ func (o *GetContactpointsExportForbidden) Code() int {
 }
 
 func (o *GetContactpointsExportForbidden) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/contact-points/export][%d] getContactpointsExportForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/contact-points/export][%d] getContactpointsExportForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetContactpointsExportForbidden) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/contact-points/export][%d] getContactpointsExportForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/contact-points/export][%d] getContactpointsExportForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetContactpointsExportForbidden) GetPayload() models.PermissionDenied {

--- a/client/provisioning/get_contactpoints_responses.go
+++ b/client/provisioning/get_contactpoints_responses.go
@@ -30,7 +30,7 @@ func (o *GetContactpointsReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/contact-points] GetContactpoints", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/contact-points] GetContactpoints", response, response.Code())
 	}
 }
 
@@ -79,11 +79,11 @@ func (o *GetContactpointsOK) Code() int {
 }
 
 func (o *GetContactpointsOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/contact-points][%d] getContactpointsOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/contact-points][%d] getContactpointsOk  %+v", 200, o.Payload)
 }
 
 func (o *GetContactpointsOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/contact-points][%d] getContactpointsOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/contact-points][%d] getContactpointsOk  %+v", 200, o.Payload)
 }
 
 func (o *GetContactpointsOK) GetPayload() models.ContactPoints {

--- a/client/provisioning/get_mute_timing_responses.go
+++ b/client/provisioning/get_mute_timing_responses.go
@@ -36,7 +36,7 @@ func (o *GetMuteTimingReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/mute-timings/{name}] GetMuteTiming", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/mute-timings/{name}] GetMuteTiming", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetMuteTimingOK) Code() int {
 }
 
 func (o *GetMuteTimingOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/mute-timings/{name}][%d] getMuteTimingOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/mute-timings/{name}][%d] getMuteTimingOk  %+v", 200, o.Payload)
 }
 
 func (o *GetMuteTimingOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/mute-timings/{name}][%d] getMuteTimingOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/mute-timings/{name}][%d] getMuteTimingOk  %+v", 200, o.Payload)
 }
 
 func (o *GetMuteTimingOK) GetPayload() *models.MuteTimeInterval {
@@ -152,11 +152,11 @@ func (o *GetMuteTimingNotFound) Code() int {
 }
 
 func (o *GetMuteTimingNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/mute-timings/{name}][%d] getMuteTimingNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/mute-timings/{name}][%d] getMuteTimingNotFound ", 404)
 }
 
 func (o *GetMuteTimingNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/mute-timings/{name}][%d] getMuteTimingNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/mute-timings/{name}][%d] getMuteTimingNotFound ", 404)
 }
 
 func (o *GetMuteTimingNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_mute_timings_responses.go
+++ b/client/provisioning/get_mute_timings_responses.go
@@ -30,7 +30,7 @@ func (o *GetMuteTimingsReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/mute-timings] GetMuteTimings", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/mute-timings] GetMuteTimings", response, response.Code())
 	}
 }
 
@@ -79,11 +79,11 @@ func (o *GetMuteTimingsOK) Code() int {
 }
 
 func (o *GetMuteTimingsOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/mute-timings][%d] getMuteTimingsOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/mute-timings][%d] getMuteTimingsOk  %+v", 200, o.Payload)
 }
 
 func (o *GetMuteTimingsOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/mute-timings][%d] getMuteTimingsOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/mute-timings][%d] getMuteTimingsOk  %+v", 200, o.Payload)
 }
 
 func (o *GetMuteTimingsOK) GetPayload() models.MuteTimings {

--- a/client/provisioning/get_policy_tree_export_responses.go
+++ b/client/provisioning/get_policy_tree_export_responses.go
@@ -36,7 +36,7 @@ func (o *GetPolicyTreeExportReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/policies/export] GetPolicyTreeExport", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/policies/export] GetPolicyTreeExport", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetPolicyTreeExportOK) Code() int {
 }
 
 func (o *GetPolicyTreeExportOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/policies/export][%d] getPolicyTreeExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/policies/export][%d] getPolicyTreeExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetPolicyTreeExportOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/policies/export][%d] getPolicyTreeExportOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/policies/export][%d] getPolicyTreeExportOk  %+v", 200, o.Payload)
 }
 
 func (o *GetPolicyTreeExportOK) GetPayload() *models.AlertingFileExport {
@@ -153,11 +153,11 @@ func (o *GetPolicyTreeExportNotFound) Code() int {
 }
 
 func (o *GetPolicyTreeExportNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/policies/export][%d] getPolicyTreeExportNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/policies/export][%d] getPolicyTreeExportNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetPolicyTreeExportNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/policies/export][%d] getPolicyTreeExportNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/policies/export][%d] getPolicyTreeExportNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetPolicyTreeExportNotFound) GetPayload() models.NotFound {

--- a/client/provisioning/get_policy_tree_responses.go
+++ b/client/provisioning/get_policy_tree_responses.go
@@ -30,7 +30,7 @@ func (o *GetPolicyTreeReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/policies] GetPolicyTree", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/policies] GetPolicyTree", response, response.Code())
 	}
 }
 
@@ -79,11 +79,11 @@ func (o *GetPolicyTreeOK) Code() int {
 }
 
 func (o *GetPolicyTreeOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/policies][%d] getPolicyTreeOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/policies][%d] getPolicyTreeOk  %+v", 200, o.Payload)
 }
 
 func (o *GetPolicyTreeOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/policies][%d] getPolicyTreeOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/policies][%d] getPolicyTreeOk  %+v", 200, o.Payload)
 }
 
 func (o *GetPolicyTreeOK) GetPayload() *models.Route {

--- a/client/provisioning/get_template_responses.go
+++ b/client/provisioning/get_template_responses.go
@@ -36,7 +36,7 @@ func (o *GetTemplateReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/templates/{name}] GetTemplate", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/templates/{name}] GetTemplate", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetTemplateOK) Code() int {
 }
 
 func (o *GetTemplateOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates/{name}][%d] getTemplateOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/templates/{name}][%d] getTemplateOk  %+v", 200, o.Payload)
 }
 
 func (o *GetTemplateOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates/{name}][%d] getTemplateOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/templates/{name}][%d] getTemplateOk  %+v", 200, o.Payload)
 }
 
 func (o *GetTemplateOK) GetPayload() *models.NotificationTemplate {
@@ -152,11 +152,11 @@ func (o *GetTemplateNotFound) Code() int {
 }
 
 func (o *GetTemplateNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates/{name}][%d] getTemplateNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/templates/{name}][%d] getTemplateNotFound ", 404)
 }
 
 func (o *GetTemplateNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates/{name}][%d] getTemplateNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/templates/{name}][%d] getTemplateNotFound ", 404)
 }
 
 func (o *GetTemplateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/get_templates_responses.go
+++ b/client/provisioning/get_templates_responses.go
@@ -36,7 +36,7 @@ func (o *GetTemplatesReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[GET /api/v1/provisioning/templates] GetTemplates", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /v1/provisioning/templates] GetTemplates", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *GetTemplatesOK) Code() int {
 }
 
 func (o *GetTemplatesOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates][%d] getTemplatesOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/templates][%d] getTemplatesOk  %+v", 200, o.Payload)
 }
 
 func (o *GetTemplatesOK) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates][%d] getTemplatesOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/provisioning/templates][%d] getTemplatesOk  %+v", 200, o.Payload)
 }
 
 func (o *GetTemplatesOK) GetPayload() models.NotificationTemplates {
@@ -150,11 +150,11 @@ func (o *GetTemplatesNotFound) Code() int {
 }
 
 func (o *GetTemplatesNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates][%d] getTemplatesNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/templates][%d] getTemplatesNotFound ", 404)
 }
 
 func (o *GetTemplatesNotFound) String() string {
-	return fmt.Sprintf("[GET /api/v1/provisioning/templates][%d] getTemplatesNotFound ", 404)
+	return fmt.Sprintf("[GET /v1/provisioning/templates][%d] getTemplatesNotFound ", 404)
 }
 
 func (o *GetTemplatesNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/client/provisioning/post_alert_rule_responses.go
+++ b/client/provisioning/post_alert_rule_responses.go
@@ -36,7 +36,7 @@ func (o *PostAlertRuleReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[POST /api/v1/provisioning/alert-rules] PostAlertRule", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /v1/provisioning/alert-rules] PostAlertRule", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PostAlertRuleCreated) Code() int {
 }
 
 func (o *PostAlertRuleCreated) Error() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/alert-rules][%d] postAlertRuleCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/alert-rules][%d] postAlertRuleCreated  %+v", 201, o.Payload)
 }
 
 func (o *PostAlertRuleCreated) String() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/alert-rules][%d] postAlertRuleCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/alert-rules][%d] postAlertRuleCreated  %+v", 201, o.Payload)
 }
 
 func (o *PostAlertRuleCreated) GetPayload() *models.ProvisionedAlertRule {
@@ -153,11 +153,11 @@ func (o *PostAlertRuleBadRequest) Code() int {
 }
 
 func (o *PostAlertRuleBadRequest) Error() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/alert-rules][%d] postAlertRuleBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/alert-rules][%d] postAlertRuleBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostAlertRuleBadRequest) String() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/alert-rules][%d] postAlertRuleBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/alert-rules][%d] postAlertRuleBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostAlertRuleBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/post_contactpoints_responses.go
+++ b/client/provisioning/post_contactpoints_responses.go
@@ -36,7 +36,7 @@ func (o *PostContactpointsReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[POST /api/v1/provisioning/contact-points] PostContactpoints", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /v1/provisioning/contact-points] PostContactpoints", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PostContactpointsAccepted) Code() int {
 }
 
 func (o *PostContactpointsAccepted) Error() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/contact-points][%d] postContactpointsAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/contact-points][%d] postContactpointsAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PostContactpointsAccepted) String() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/contact-points][%d] postContactpointsAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/contact-points][%d] postContactpointsAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PostContactpointsAccepted) GetPayload() *models.EmbeddedContactPoint {
@@ -153,11 +153,11 @@ func (o *PostContactpointsBadRequest) Code() int {
 }
 
 func (o *PostContactpointsBadRequest) Error() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/contact-points][%d] postContactpointsBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/contact-points][%d] postContactpointsBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostContactpointsBadRequest) String() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/contact-points][%d] postContactpointsBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/contact-points][%d] postContactpointsBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostContactpointsBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/post_mute_timing_responses.go
+++ b/client/provisioning/post_mute_timing_responses.go
@@ -36,7 +36,7 @@ func (o *PostMuteTimingReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[POST /api/v1/provisioning/mute-timings] PostMuteTiming", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /v1/provisioning/mute-timings] PostMuteTiming", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PostMuteTimingCreated) Code() int {
 }
 
 func (o *PostMuteTimingCreated) Error() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/mute-timings][%d] postMuteTimingCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/mute-timings][%d] postMuteTimingCreated  %+v", 201, o.Payload)
 }
 
 func (o *PostMuteTimingCreated) String() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/mute-timings][%d] postMuteTimingCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/mute-timings][%d] postMuteTimingCreated  %+v", 201, o.Payload)
 }
 
 func (o *PostMuteTimingCreated) GetPayload() *models.MuteTimeInterval {
@@ -153,11 +153,11 @@ func (o *PostMuteTimingBadRequest) Code() int {
 }
 
 func (o *PostMuteTimingBadRequest) Error() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/mute-timings][%d] postMuteTimingBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/mute-timings][%d] postMuteTimingBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostMuteTimingBadRequest) String() string {
-	return fmt.Sprintf("[POST /api/v1/provisioning/mute-timings][%d] postMuteTimingBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/provisioning/mute-timings][%d] postMuteTimingBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostMuteTimingBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/provisioning_client.go
+++ b/client/provisioning/provisioning_client.go
@@ -100,7 +100,7 @@ func (a *Client) DeleteAlertRule(params *DeleteAlertRuleParams, authInfo runtime
 	op := &runtime.ClientOperation{
 		ID:                 "DeleteAlertRule",
 		Method:             "DELETE",
-		PathPattern:        "/api/v1/provisioning/alert-rules/{UID}",
+		PathPattern:        "/v1/provisioning/alert-rules/{UID}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -139,7 +139,7 @@ func (a *Client) DeleteContactpoints(params *DeleteContactpointsParams, authInfo
 	op := &runtime.ClientOperation{
 		ID:                 "DeleteContactpoints",
 		Method:             "DELETE",
-		PathPattern:        "/api/v1/provisioning/contact-points/{UID}",
+		PathPattern:        "/v1/provisioning/contact-points/{UID}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -178,7 +178,7 @@ func (a *Client) DeleteMuteTiming(params *DeleteMuteTimingParams, authInfo runti
 	op := &runtime.ClientOperation{
 		ID:                 "DeleteMuteTiming",
 		Method:             "DELETE",
-		PathPattern:        "/api/v1/provisioning/mute-timings/{name}",
+		PathPattern:        "/v1/provisioning/mute-timings/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -217,7 +217,7 @@ func (a *Client) DeleteTemplate(params *DeleteTemplateParams, authInfo runtime.C
 	op := &runtime.ClientOperation{
 		ID:                 "DeleteTemplate",
 		Method:             "DELETE",
-		PathPattern:        "/api/v1/provisioning/templates/{name}",
+		PathPattern:        "/v1/provisioning/templates/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -256,7 +256,7 @@ func (a *Client) GetAlertRule(params *GetAlertRuleParams, authInfo runtime.Clien
 	op := &runtime.ClientOperation{
 		ID:                 "GetAlertRule",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/alert-rules/{UID}",
+		PathPattern:        "/v1/provisioning/alert-rules/{UID}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -295,7 +295,7 @@ func (a *Client) GetAlertRuleExport(params *GetAlertRuleExportParams, authInfo r
 	op := &runtime.ClientOperation{
 		ID:                 "GetAlertRuleExport",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/alert-rules/{UID}/export",
+		PathPattern:        "/v1/provisioning/alert-rules/{UID}/export",
 		ProducesMediaTypes: []string{"application/json", "application/yaml", "text/yaml"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -334,7 +334,7 @@ func (a *Client) GetAlertRuleGroup(params *GetAlertRuleGroupParams, authInfo run
 	op := &runtime.ClientOperation{
 		ID:                 "GetAlertRuleGroup",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
+		PathPattern:        "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -373,7 +373,7 @@ func (a *Client) GetAlertRuleGroupExport(params *GetAlertRuleGroupExportParams, 
 	op := &runtime.ClientOperation{
 		ID:                 "GetAlertRuleGroupExport",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export",
+		PathPattern:        "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export",
 		ProducesMediaTypes: []string{"application/json", "application/yaml", "text/yaml"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -412,7 +412,7 @@ func (a *Client) GetAlertRules(params *GetAlertRulesParams, authInfo runtime.Cli
 	op := &runtime.ClientOperation{
 		ID:                 "GetAlertRules",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/alert-rules",
+		PathPattern:        "/v1/provisioning/alert-rules",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -451,7 +451,7 @@ func (a *Client) GetAlertRulesExport(params *GetAlertRulesExportParams, authInfo
 	op := &runtime.ClientOperation{
 		ID:                 "GetAlertRulesExport",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/alert-rules/export",
+		PathPattern:        "/v1/provisioning/alert-rules/export",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -490,7 +490,7 @@ func (a *Client) GetContactpoints(params *GetContactpointsParams, authInfo runti
 	op := &runtime.ClientOperation{
 		ID:                 "GetContactpoints",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/contact-points",
+		PathPattern:        "/v1/provisioning/contact-points",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -529,7 +529,7 @@ func (a *Client) GetContactpointsExport(params *GetContactpointsExportParams, au
 	op := &runtime.ClientOperation{
 		ID:                 "GetContactpointsExport",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/contact-points/export",
+		PathPattern:        "/v1/provisioning/contact-points/export",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -568,7 +568,7 @@ func (a *Client) GetMuteTiming(params *GetMuteTimingParams, authInfo runtime.Cli
 	op := &runtime.ClientOperation{
 		ID:                 "GetMuteTiming",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/mute-timings/{name}",
+		PathPattern:        "/v1/provisioning/mute-timings/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -607,7 +607,7 @@ func (a *Client) GetMuteTimings(params *GetMuteTimingsParams, authInfo runtime.C
 	op := &runtime.ClientOperation{
 		ID:                 "GetMuteTimings",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/mute-timings",
+		PathPattern:        "/v1/provisioning/mute-timings",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -646,7 +646,7 @@ func (a *Client) GetPolicyTree(params *GetPolicyTreeParams, authInfo runtime.Cli
 	op := &runtime.ClientOperation{
 		ID:                 "GetPolicyTree",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/policies",
+		PathPattern:        "/v1/provisioning/policies",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -685,7 +685,7 @@ func (a *Client) GetPolicyTreeExport(params *GetPolicyTreeExportParams, authInfo
 	op := &runtime.ClientOperation{
 		ID:                 "GetPolicyTreeExport",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/policies/export",
+		PathPattern:        "/v1/provisioning/policies/export",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -724,7 +724,7 @@ func (a *Client) GetTemplate(params *GetTemplateParams, authInfo runtime.ClientA
 	op := &runtime.ClientOperation{
 		ID:                 "GetTemplate",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/templates/{name}",
+		PathPattern:        "/v1/provisioning/templates/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -763,7 +763,7 @@ func (a *Client) GetTemplates(params *GetTemplatesParams, authInfo runtime.Clien
 	op := &runtime.ClientOperation{
 		ID:                 "GetTemplates",
 		Method:             "GET",
-		PathPattern:        "/api/v1/provisioning/templates",
+		PathPattern:        "/v1/provisioning/templates",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -802,7 +802,7 @@ func (a *Client) PostAlertRule(params *PostAlertRuleParams, authInfo runtime.Cli
 	op := &runtime.ClientOperation{
 		ID:                 "PostAlertRule",
 		Method:             "POST",
-		PathPattern:        "/api/v1/provisioning/alert-rules",
+		PathPattern:        "/v1/provisioning/alert-rules",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -841,7 +841,7 @@ func (a *Client) PostContactpoints(params *PostContactpointsParams, authInfo run
 	op := &runtime.ClientOperation{
 		ID:                 "PostContactpoints",
 		Method:             "POST",
-		PathPattern:        "/api/v1/provisioning/contact-points",
+		PathPattern:        "/v1/provisioning/contact-points",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -880,7 +880,7 @@ func (a *Client) PostMuteTiming(params *PostMuteTimingParams, authInfo runtime.C
 	op := &runtime.ClientOperation{
 		ID:                 "PostMuteTiming",
 		Method:             "POST",
-		PathPattern:        "/api/v1/provisioning/mute-timings",
+		PathPattern:        "/v1/provisioning/mute-timings",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -919,7 +919,7 @@ func (a *Client) PutAlertRule(params *PutAlertRuleParams, authInfo runtime.Clien
 	op := &runtime.ClientOperation{
 		ID:                 "PutAlertRule",
 		Method:             "PUT",
-		PathPattern:        "/api/v1/provisioning/alert-rules/{UID}",
+		PathPattern:        "/v1/provisioning/alert-rules/{UID}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -958,7 +958,7 @@ func (a *Client) PutAlertRuleGroup(params *PutAlertRuleGroupParams, authInfo run
 	op := &runtime.ClientOperation{
 		ID:                 "PutAlertRuleGroup",
 		Method:             "PUT",
-		PathPattern:        "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
+		PathPattern:        "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -997,7 +997,7 @@ func (a *Client) PutContactpoint(params *PutContactpointParams, authInfo runtime
 	op := &runtime.ClientOperation{
 		ID:                 "PutContactpoint",
 		Method:             "PUT",
-		PathPattern:        "/api/v1/provisioning/contact-points/{UID}",
+		PathPattern:        "/v1/provisioning/contact-points/{UID}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1036,7 +1036,7 @@ func (a *Client) PutMuteTiming(params *PutMuteTimingParams, authInfo runtime.Cli
 	op := &runtime.ClientOperation{
 		ID:                 "PutMuteTiming",
 		Method:             "PUT",
-		PathPattern:        "/api/v1/provisioning/mute-timings/{name}",
+		PathPattern:        "/v1/provisioning/mute-timings/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1075,7 +1075,7 @@ func (a *Client) PutPolicyTree(params *PutPolicyTreeParams, authInfo runtime.Cli
 	op := &runtime.ClientOperation{
 		ID:                 "PutPolicyTree",
 		Method:             "PUT",
-		PathPattern:        "/api/v1/provisioning/policies",
+		PathPattern:        "/v1/provisioning/policies",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1114,7 +1114,7 @@ func (a *Client) PutTemplate(params *PutTemplateParams, authInfo runtime.ClientA
 	op := &runtime.ClientOperation{
 		ID:                 "PutTemplate",
 		Method:             "PUT",
-		PathPattern:        "/api/v1/provisioning/templates/{name}",
+		PathPattern:        "/v1/provisioning/templates/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1153,7 +1153,7 @@ func (a *Client) ResetPolicyTree(params *ResetPolicyTreeParams, authInfo runtime
 	op := &runtime.ClientOperation{
 		ID:                 "ResetPolicyTree",
 		Method:             "DELETE",
-		PathPattern:        "/api/v1/provisioning/policies",
+		PathPattern:        "/v1/provisioning/policies",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/provisioning/put_alert_rule_group_responses.go
+++ b/client/provisioning/put_alert_rule_group_responses.go
@@ -36,7 +36,7 @@ func (o *PutAlertRuleGroupReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}] PutAlertRuleGroup", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}] PutAlertRuleGroup", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PutAlertRuleGroupOK) Code() int {
 }
 
 func (o *PutAlertRuleGroupOK) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupOk  %+v", 200, o.Payload)
 }
 
 func (o *PutAlertRuleGroupOK) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupOk  %+v", 200, o.Payload)
 }
 
 func (o *PutAlertRuleGroupOK) GetPayload() *models.AlertRuleGroup {
@@ -153,11 +153,11 @@ func (o *PutAlertRuleGroupBadRequest) Code() int {
 }
 
 func (o *PutAlertRuleGroupBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutAlertRuleGroupBadRequest) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}][%d] putAlertRuleGroupBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutAlertRuleGroupBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/put_alert_rule_responses.go
+++ b/client/provisioning/put_alert_rule_responses.go
@@ -36,7 +36,7 @@ func (o *PutAlertRuleReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[PUT /api/v1/provisioning/alert-rules/{UID}] PutAlertRule", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /v1/provisioning/alert-rules/{UID}] PutAlertRule", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PutAlertRuleOK) Code() int {
 }
 
 func (o *PutAlertRuleOK) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/alert-rules/{UID}][%d] putAlertRuleOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/alert-rules/{UID}][%d] putAlertRuleOk  %+v", 200, o.Payload)
 }
 
 func (o *PutAlertRuleOK) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/alert-rules/{UID}][%d] putAlertRuleOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/alert-rules/{UID}][%d] putAlertRuleOk  %+v", 200, o.Payload)
 }
 
 func (o *PutAlertRuleOK) GetPayload() *models.ProvisionedAlertRule {
@@ -153,11 +153,11 @@ func (o *PutAlertRuleBadRequest) Code() int {
 }
 
 func (o *PutAlertRuleBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/alert-rules/{UID}][%d] putAlertRuleBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/alert-rules/{UID}][%d] putAlertRuleBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutAlertRuleBadRequest) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/alert-rules/{UID}][%d] putAlertRuleBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/alert-rules/{UID}][%d] putAlertRuleBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutAlertRuleBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/put_contactpoint_responses.go
+++ b/client/provisioning/put_contactpoint_responses.go
@@ -36,7 +36,7 @@ func (o *PutContactpointReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[PUT /api/v1/provisioning/contact-points/{UID}] PutContactpoint", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /v1/provisioning/contact-points/{UID}] PutContactpoint", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PutContactpointAccepted) Code() int {
 }
 
 func (o *PutContactpointAccepted) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/contact-points/{UID}][%d] putContactpointAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/contact-points/{UID}][%d] putContactpointAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PutContactpointAccepted) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/contact-points/{UID}][%d] putContactpointAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/contact-points/{UID}][%d] putContactpointAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PutContactpointAccepted) GetPayload() models.Ack {
@@ -151,11 +151,11 @@ func (o *PutContactpointBadRequest) Code() int {
 }
 
 func (o *PutContactpointBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/contact-points/{UID}][%d] putContactpointBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/contact-points/{UID}][%d] putContactpointBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutContactpointBadRequest) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/contact-points/{UID}][%d] putContactpointBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/contact-points/{UID}][%d] putContactpointBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutContactpointBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/put_mute_timing_responses.go
+++ b/client/provisioning/put_mute_timing_responses.go
@@ -36,7 +36,7 @@ func (o *PutMuteTimingReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[PUT /api/v1/provisioning/mute-timings/{name}] PutMuteTiming", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /v1/provisioning/mute-timings/{name}] PutMuteTiming", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PutMuteTimingOK) Code() int {
 }
 
 func (o *PutMuteTimingOK) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/mute-timings/{name}][%d] putMuteTimingOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/mute-timings/{name}][%d] putMuteTimingOk  %+v", 200, o.Payload)
 }
 
 func (o *PutMuteTimingOK) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/mute-timings/{name}][%d] putMuteTimingOk  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/mute-timings/{name}][%d] putMuteTimingOk  %+v", 200, o.Payload)
 }
 
 func (o *PutMuteTimingOK) GetPayload() *models.MuteTimeInterval {
@@ -153,11 +153,11 @@ func (o *PutMuteTimingBadRequest) Code() int {
 }
 
 func (o *PutMuteTimingBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/mute-timings/{name}][%d] putMuteTimingBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/mute-timings/{name}][%d] putMuteTimingBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutMuteTimingBadRequest) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/mute-timings/{name}][%d] putMuteTimingBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/mute-timings/{name}][%d] putMuteTimingBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutMuteTimingBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/put_policy_tree_responses.go
+++ b/client/provisioning/put_policy_tree_responses.go
@@ -36,7 +36,7 @@ func (o *PutPolicyTreeReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[PUT /api/v1/provisioning/policies] PutPolicyTree", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /v1/provisioning/policies] PutPolicyTree", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PutPolicyTreeAccepted) Code() int {
 }
 
 func (o *PutPolicyTreeAccepted) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/policies][%d] putPolicyTreeAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/policies][%d] putPolicyTreeAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PutPolicyTreeAccepted) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/policies][%d] putPolicyTreeAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/policies][%d] putPolicyTreeAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PutPolicyTreeAccepted) GetPayload() models.Ack {
@@ -151,11 +151,11 @@ func (o *PutPolicyTreeBadRequest) Code() int {
 }
 
 func (o *PutPolicyTreeBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/policies][%d] putPolicyTreeBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/policies][%d] putPolicyTreeBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutPolicyTreeBadRequest) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/policies][%d] putPolicyTreeBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/policies][%d] putPolicyTreeBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutPolicyTreeBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/put_template_responses.go
+++ b/client/provisioning/put_template_responses.go
@@ -36,7 +36,7 @@ func (o *PutTemplateReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("[PUT /api/v1/provisioning/templates/{name}] PutTemplate", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /v1/provisioning/templates/{name}] PutTemplate", response, response.Code())
 	}
 }
 
@@ -85,11 +85,11 @@ func (o *PutTemplateAccepted) Code() int {
 }
 
 func (o *PutTemplateAccepted) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/templates/{name}][%d] putTemplateAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/templates/{name}][%d] putTemplateAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PutTemplateAccepted) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/templates/{name}][%d] putTemplateAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/templates/{name}][%d] putTemplateAccepted  %+v", 202, o.Payload)
 }
 
 func (o *PutTemplateAccepted) GetPayload() *models.NotificationTemplate {
@@ -153,11 +153,11 @@ func (o *PutTemplateBadRequest) Code() int {
 }
 
 func (o *PutTemplateBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/templates/{name}][%d] putTemplateBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/templates/{name}][%d] putTemplateBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutTemplateBadRequest) String() string {
-	return fmt.Sprintf("[PUT /api/v1/provisioning/templates/{name}][%d] putTemplateBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/provisioning/templates/{name}][%d] putTemplateBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PutTemplateBadRequest) GetPayload() *models.ValidationError {

--- a/client/provisioning/reset_policy_tree_responses.go
+++ b/client/provisioning/reset_policy_tree_responses.go
@@ -30,7 +30,7 @@ func (o *ResetPolicyTreeReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("[DELETE /api/v1/provisioning/policies] ResetPolicyTree", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /v1/provisioning/policies] ResetPolicyTree", response, response.Code())
 	}
 }
 
@@ -79,11 +79,11 @@ func (o *ResetPolicyTreeAccepted) Code() int {
 }
 
 func (o *ResetPolicyTreeAccepted) Error() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/policies][%d] resetPolicyTreeAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/provisioning/policies][%d] resetPolicyTreeAccepted  %+v", 202, o.Payload)
 }
 
 func (o *ResetPolicyTreeAccepted) String() string {
-	return fmt.Sprintf("[DELETE /api/v1/provisioning/policies][%d] resetPolicyTreeAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/provisioning/policies][%d] resetPolicyTreeAccepted  %+v", 202, o.Payload)
 }
 
 func (o *ResetPolicyTreeAccepted) GetPayload() models.Ack {

--- a/models/provisioned_alert_rule.go
+++ b/models/provisioned_alert_rule.go
@@ -47,7 +47,8 @@ type ProvisionedAlertRule struct {
 
 	// for
 	// Required: true
-	For *Duration `json:"for"`
+	// Format: duration
+	For *strfmt.Duration `json:"for"`
 
 	// id
 	ID int64 `json:"id,omitempty"`
@@ -253,19 +254,8 @@ func (m *ProvisionedAlertRule) validateFor(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Required("for", "body", m.For); err != nil {
+	if err := validate.FormatOf("for", "body", "duration", m.For.String(), formats); err != nil {
 		return err
-	}
-
-	if m.For != nil {
-		if err := m.For.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("for")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("for")
-			}
-			return err
-		}
 	}
 
 	return nil
@@ -417,10 +407,6 @@ func (m *ProvisionedAlertRule) ContextValidate(ctx context.Context, formats strf
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateFor(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateProvenance(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -455,23 +441,6 @@ func (m *ProvisionedAlertRule) contextValidateData(ctx context.Context, formats 
 			}
 		}
 
-	}
-
-	return nil
-}
-
-func (m *ProvisionedAlertRule) contextValidateFor(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.For != nil {
-
-		if err := m.For.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("for")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("for")
-			}
-			return err
-		}
 	}
 
 	return nil

--- a/models/route_export.go
+++ b/models/route_export.go
@@ -69,10 +69,6 @@ func (m *RouteExport) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateObjectMatchers(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateRoutes(formats); err != nil {
 		res = append(res, err)
 	}
@@ -119,23 +115,6 @@ func (m *RouteExport) validateMatchers(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *RouteExport) validateObjectMatchers(formats strfmt.Registry) error {
-	if swag.IsZero(m.ObjectMatchers) { // not required
-		return nil
-	}
-
-	if err := m.ObjectMatchers.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("object_matchers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("object_matchers")
-		}
-		return err
-	}
-
-	return nil
-}
-
 func (m *RouteExport) validateRoutes(formats strfmt.Registry) error {
 	if swag.IsZero(m.Routes) { // not required
 		return nil
@@ -174,10 +153,6 @@ func (m *RouteExport) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateObjectMatchers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateRoutes(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -213,20 +188,6 @@ func (m *RouteExport) contextValidateMatchers(ctx context.Context, formats strfm
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *RouteExport) contextValidateObjectMatchers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := m.ObjectMatchers.ContextValidate(ctx, formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("object_matchers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -12,12 +12,12 @@ modify() {
     SCHEMA="$(echo "${SCHEMA}" | jq "${1}")"
 }
 
-modify '.definitions.Spec["x-go-name"] = "Preferences"'
+# Playlist models are all messed up
+# TODO: Upstream fix
 modify 'del(.definitions.Item)' # Old playlist item schema, PlaylistItem is more up to date
 modify '.responses.getPlaylistItemsResponse.schema.items["$ref"] = "#/definitions/PlaylistItem"' # Currently pointing to Item (old PlaylistItem model)
 modify '.responses.updatePlaylistResponse.schema["$ref"] = "#/definitions/Playlist"' # Currently pointing to Spec (Preferences)
 modify '.responses.getPlaylistResponse.schema["$ref"] = "#/definitions/Playlist"' # Currently pointing to Spec (Preferences)
-modify '.paths = .paths | walk(if type == "object" and has("operationId") then .operationId |= sub("^Route";"") else . end)' # Remove "Route" prefixes to operation IDs (ex: RouteGetxxx)
 
 # Fixed in the grafana repo here: https://github.com/grafana/grafana/pull/77605
 modify '.definitions.ItemDTO["x-go-name"] = "Annotation"'
@@ -57,6 +57,18 @@ modify '.responses.getLibraryElementArrayResponse = {
         "$ref": "#/definitions/LibraryElementArrayResponse"
     }
 }'
+
+# Fixed in the grafana repo here: https://github.com/grafana/grafana/pull/78226
+modify '.definitions.Spec["x-go-name"] = "Preferences"'
+
+# Any endpoint that starts with /api/ should be trimmed because it's redundant (API path is configured on the client), ex: /api/dashboards/ -> /dashboards/
+# TODO: Upstream fix
+# Move /api/ map keys to a new key without /api/ prefix
+modify '.paths = (.paths | with_entries(.key |= sub("^/api"; "")))'
+
+# Remove "Route" prefixes to operation IDs (ex: RouteGetxxx)
+# TODO: Upstream fix
+modify '.paths = .paths | walk(if type == "object" and has("operationId") then .operationId |= sub("^Route";"") else . end)' 
 
 # Write the schema to a file
 echo "${SCHEMA}" > "${SCRIPT_DIR}/schema.json"

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -70,5 +70,12 @@ modify '.paths = (.paths | with_entries(.key |= sub("^/api"; "")))'
 # TODO: Upstream fix
 modify '.paths = .paths | walk(if type == "object" and has("operationId") then .operationId |= sub("^Route";"") else . end)' 
 
+# The "for" property returned by the API is a string (can't be unmarshaled to time.Duration)
+# TODO: Upstream fix
+modify '.definitions.ProvisionedAlertRule.properties.for = {
+    "type": "string",
+    "format": "duration"
+}'
+
 # Write the schema to a file
 echo "${SCHEMA}" > "${SCRIPT_DIR}/schema.json"


### PR DESCRIPTION
The schema doubles the `/api`, so the client doesn't work. See `pull-schema.sh` for the actual changes I made (rest is generation)