### PR TITLE
Add missing `global` attribute on Role

### DIFF
--- a/models/role_dto.go
+++ b/models/role_dto.go
@@ -33,6 +33,9 @@ type RoleDTO struct {
 	// display name
 	DisplayName string `json:"displayName,omitempty"`
 
+	// Whether the role is global or not.
+	Global bool `json:"global,omitempty"`
+
 	// group
 	Group string `json:"group,omitempty"`
 

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -77,5 +77,13 @@ modify '.definitions.ProvisionedAlertRule.properties.for = {
     "format": "duration"
 }'
 
+# The global property is not in the RoleDTO model, it is added in the MarshalJSON method
+# As a result, it is not found by go-swagger, but it's still useful
+# TODO: Upstream fix
+modify '.definitions.RoleDTO.properties.global = {
+    "type": "boolean",
+    "description": "Whether the role is global or not."
+}'
+
 # Write the schema to a file
 echo "${SCHEMA}" > "${SCRIPT_DIR}/schema.json"


### PR DESCRIPTION
This one is tricky. It's added on MarshalJSON so it's not present in the struct. go-swagger misses it