### PR TITLE
Usability improvement: Do not require params obj if the API call requires none

### DIFF
--- a/client/access_control/access_control_client.go
+++ b/client/access_control/access_control_client.go
@@ -38,7 +38,8 @@ type ClientService interface {
 
 	DeleteRole(params *DeleteRoleParams, opts ...ClientOption) (*DeleteRoleOK, error)
 
-	GetAccessControlStatus(params *GetAccessControlStatusParams, opts ...ClientOption) (*GetAccessControlStatusOK, error)
+	GetAccessControlStatus(opts ...ClientOption) (*GetAccessControlStatusOK, error)
+	GetAccessControlStatusWithParams(params *GetAccessControlStatusParams, opts ...ClientOption) (*GetAccessControlStatusOK, error)
 
 	GetRole(params *GetRoleParams, opts ...ClientOption) (*GetRoleOK, error)
 
@@ -243,7 +244,11 @@ func (a *Client) DeleteRole(params *DeleteRoleParams, opts ...ClientOption) (*De
 
 You need to have a permission with action `status:accesscontrol` and scope `services:accesscontrol`.
 */
-func (a *Client) GetAccessControlStatus(params *GetAccessControlStatusParams, opts ...ClientOption) (*GetAccessControlStatusOK, error) {
+func (a *Client) GetAccessControlStatus(opts ...ClientOption) (*GetAccessControlStatusOK, error) {
+	return a.GetAccessControlStatusWithParams(nil, opts...)
+}
+
+func (a *Client) GetAccessControlStatusWithParams(params *GetAccessControlStatusParams, opts ...ClientOption) (*GetAccessControlStatusOK, error) {
 	if params == nil {
 		params = NewGetAccessControlStatusParams()
 	}

--- a/client/access_control_provisioning/access_control_provisioning_client.go
+++ b/client/access_control_provisioning/access_control_provisioning_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AdminProvisioningReloadAccessControl(params *AdminProvisioningReloadAccessControlParams, opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error)
+	AdminProvisioningReloadAccessControl(opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error)
+	AdminProvisioningReloadAccessControlWithParams(params *AdminProvisioningReloadAccessControlParams, opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -38,7 +39,11 @@ type ClientService interface {
 /*
 AdminProvisioningReloadAccessControl yous need to have a permission with action provisioning reload with scope provisioners accesscontrol
 */
-func (a *Client) AdminProvisioningReloadAccessControl(params *AdminProvisioningReloadAccessControlParams, opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error) {
+func (a *Client) AdminProvisioningReloadAccessControl(opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error) {
+	return a.AdminProvisioningReloadAccessControlWithParams(nil, opts...)
+}
+
+func (a *Client) AdminProvisioningReloadAccessControlWithParams(params *AdminProvisioningReloadAccessControlParams, opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error) {
 	if params == nil {
 		params = NewAdminProvisioningReloadAccessControlParams()
 	}

--- a/client/admin/admin_client.go
+++ b/client/admin/admin_client.go
@@ -30,9 +30,11 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AdminGetSettings(params *AdminGetSettingsParams, opts ...ClientOption) (*AdminGetSettingsOK, error)
+	AdminGetSettings(opts ...ClientOption) (*AdminGetSettingsOK, error)
+	AdminGetSettingsWithParams(params *AdminGetSettingsParams, opts ...ClientOption) (*AdminGetSettingsOK, error)
 
-	AdminGetStats(params *AdminGetStatsParams, opts ...ClientOption) (*AdminGetStatsOK, error)
+	AdminGetStats(opts ...ClientOption) (*AdminGetStatsOK, error)
+	AdminGetStatsWithParams(params *AdminGetStatsParams, opts ...ClientOption) (*AdminGetStatsOK, error)
 
 	PauseAllAlerts(params *PauseAllAlertsParams, opts ...ClientOption) (*PauseAllAlertsOK, error)
 
@@ -44,7 +46,11 @@ AdminGetSettings fetches settings
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `settings:read` and scopes: `settings:*`, `settings:auth.saml:` and `settings:auth.saml:enabled` (property level).
 */
-func (a *Client) AdminGetSettings(params *AdminGetSettingsParams, opts ...ClientOption) (*AdminGetSettingsOK, error) {
+func (a *Client) AdminGetSettings(opts ...ClientOption) (*AdminGetSettingsOK, error) {
+	return a.AdminGetSettingsWithParams(nil, opts...)
+}
+
+func (a *Client) AdminGetSettingsWithParams(params *AdminGetSettingsParams, opts ...ClientOption) (*AdminGetSettingsOK, error) {
 	if params == nil {
 		params = NewAdminGetSettingsParams()
 	}
@@ -87,7 +93,11 @@ func (a *Client) AdminGetSettings(params *AdminGetSettingsParams, opts ...Client
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `server:stats:read`.
 */
-func (a *Client) AdminGetStats(params *AdminGetStatsParams, opts ...ClientOption) (*AdminGetStatsOK, error) {
+func (a *Client) AdminGetStats(opts ...ClientOption) (*AdminGetStatsOK, error) {
+	return a.AdminGetStatsWithParams(nil, opts...)
+}
+
+func (a *Client) AdminGetStatsWithParams(params *AdminGetStatsParams, opts ...ClientOption) (*AdminGetStatsOK, error) {
 	if params == nil {
 		params = NewAdminGetStatsParams()
 	}

--- a/client/admin_ldap/admin_ldap_client.go
+++ b/client/admin_ldap/admin_ldap_client.go
@@ -30,13 +30,15 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetLDAPStatus(params *GetLDAPStatusParams, opts ...ClientOption) (*GetLDAPStatusOK, error)
+	GetLDAPStatus(opts ...ClientOption) (*GetLDAPStatusOK, error)
+	GetLDAPStatusWithParams(params *GetLDAPStatusParams, opts ...ClientOption) (*GetLDAPStatusOK, error)
 
 	GetUserFromLDAP(params *GetUserFromLDAPParams, opts ...ClientOption) (*GetUserFromLDAPOK, error)
 
 	PostSyncUserWithLDAP(params *PostSyncUserWithLDAPParams, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error)
 
-	ReloadLDAPCfg(params *ReloadLDAPCfgParams, opts ...ClientOption) (*ReloadLDAPCfgOK, error)
+	ReloadLDAPCfg(opts ...ClientOption) (*ReloadLDAPCfgOK, error)
+	ReloadLDAPCfgWithParams(params *ReloadLDAPCfgParams, opts ...ClientOption) (*ReloadLDAPCfgOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -46,7 +48,11 @@ GetLDAPStatus attempts to connect to all the configured LDAP servers and returns
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `ldap.status:read`.
 */
-func (a *Client) GetLDAPStatus(params *GetLDAPStatusParams, opts ...ClientOption) (*GetLDAPStatusOK, error) {
+func (a *Client) GetLDAPStatus(opts ...ClientOption) (*GetLDAPStatusOK, error) {
+	return a.GetLDAPStatusWithParams(nil, opts...)
+}
+
+func (a *Client) GetLDAPStatusWithParams(params *GetLDAPStatusParams, opts ...ClientOption) (*GetLDAPStatusOK, error) {
 	if params == nil {
 		params = NewGetLDAPStatusParams()
 	}
@@ -169,7 +175,11 @@ ReloadLDAPCfg reloads the LDAP configuration
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `ldap.config:reload`.
 */
-func (a *Client) ReloadLDAPCfg(params *ReloadLDAPCfgParams, opts ...ClientOption) (*ReloadLDAPCfgOK, error) {
+func (a *Client) ReloadLDAPCfg(opts ...ClientOption) (*ReloadLDAPCfgOK, error) {
+	return a.ReloadLDAPCfgWithParams(nil, opts...)
+}
+
+func (a *Client) ReloadLDAPCfgWithParams(params *ReloadLDAPCfgParams, opts ...ClientOption) (*ReloadLDAPCfgOK, error) {
 	if params == nil {
 		params = NewReloadLDAPCfgParams()
 	}

--- a/client/admin_provisioning/admin_provisioning_client.go
+++ b/client/admin_provisioning/admin_provisioning_client.go
@@ -30,13 +30,17 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AdminProvisioningReloadDashboards(params *AdminProvisioningReloadDashboardsParams, opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error)
+	AdminProvisioningReloadDashboards(opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error)
+	AdminProvisioningReloadDashboardsWithParams(params *AdminProvisioningReloadDashboardsParams, opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error)
 
-	AdminProvisioningReloadDatasources(params *AdminProvisioningReloadDatasourcesParams, opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error)
+	AdminProvisioningReloadDatasources(opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error)
+	AdminProvisioningReloadDatasourcesWithParams(params *AdminProvisioningReloadDatasourcesParams, opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error)
 
-	AdminProvisioningReloadNotifications(params *AdminProvisioningReloadNotificationsParams, opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error)
+	AdminProvisioningReloadNotifications(opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error)
+	AdminProvisioningReloadNotificationsWithParams(params *AdminProvisioningReloadNotificationsParams, opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error)
 
-	AdminProvisioningReloadPlugins(params *AdminProvisioningReloadPluginsParams, opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error)
+	AdminProvisioningReloadPlugins(opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error)
+	AdminProvisioningReloadPluginsWithParams(params *AdminProvisioningReloadPluginsParams, opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -48,7 +52,11 @@ type ClientService interface {
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:dashboards`.
 */
-func (a *Client) AdminProvisioningReloadDashboards(params *AdminProvisioningReloadDashboardsParams, opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error) {
+func (a *Client) AdminProvisioningReloadDashboards(opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error) {
+	return a.AdminProvisioningReloadDashboardsWithParams(nil, opts...)
+}
+
+func (a *Client) AdminProvisioningReloadDashboardsWithParams(params *AdminProvisioningReloadDashboardsParams, opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error) {
 	if params == nil {
 		params = NewAdminProvisioningReloadDashboardsParams()
 	}
@@ -91,7 +99,11 @@ func (a *Client) AdminProvisioningReloadDashboards(params *AdminProvisioningRelo
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:datasources`.
 */
-func (a *Client) AdminProvisioningReloadDatasources(params *AdminProvisioningReloadDatasourcesParams, opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error) {
+func (a *Client) AdminProvisioningReloadDatasources(opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error) {
+	return a.AdminProvisioningReloadDatasourcesWithParams(nil, opts...)
+}
+
+func (a *Client) AdminProvisioningReloadDatasourcesWithParams(params *AdminProvisioningReloadDatasourcesParams, opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error) {
 	if params == nil {
 		params = NewAdminProvisioningReloadDatasourcesParams()
 	}
@@ -134,7 +146,11 @@ func (a *Client) AdminProvisioningReloadDatasources(params *AdminProvisioningRel
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:notifications`.
 */
-func (a *Client) AdminProvisioningReloadNotifications(params *AdminProvisioningReloadNotificationsParams, opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error) {
+func (a *Client) AdminProvisioningReloadNotifications(opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error) {
+	return a.AdminProvisioningReloadNotificationsWithParams(nil, opts...)
+}
+
+func (a *Client) AdminProvisioningReloadNotificationsWithParams(params *AdminProvisioningReloadNotificationsParams, opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error) {
 	if params == nil {
 		params = NewAdminProvisioningReloadNotificationsParams()
 	}
@@ -177,7 +193,11 @@ func (a *Client) AdminProvisioningReloadNotifications(params *AdminProvisioningR
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:plugin`.
 */
-func (a *Client) AdminProvisioningReloadPlugins(params *AdminProvisioningReloadPluginsParams, opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error) {
+func (a *Client) AdminProvisioningReloadPlugins(opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error) {
+	return a.AdminProvisioningReloadPluginsWithParams(nil, opts...)
+}
+
+func (a *Client) AdminProvisioningReloadPluginsWithParams(params *AdminProvisioningReloadPluginsParams, opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error) {
 	if params == nil {
 		params = NewAdminProvisioningReloadPluginsParams()
 	}

--- a/client/dashboards/dashboards_client.go
+++ b/client/dashboards/dashboards_client.go
@@ -36,9 +36,11 @@ type ClientService interface {
 
 	GetDashboardByUID(params *GetDashboardByUIDParams, opts ...ClientOption) (*GetDashboardByUIDOK, error)
 
-	GetDashboardTags(params *GetDashboardTagsParams, opts ...ClientOption) (*GetDashboardTagsOK, error)
+	GetDashboardTags(opts ...ClientOption) (*GetDashboardTagsOK, error)
+	GetDashboardTagsWithParams(params *GetDashboardTagsParams, opts ...ClientOption) (*GetDashboardTagsOK, error)
 
-	GetHomeDashboard(params *GetHomeDashboardParams, opts ...ClientOption) (*GetHomeDashboardOK, error)
+	GetHomeDashboard(opts ...ClientOption) (*GetHomeDashboardOK, error)
+	GetHomeDashboardWithParams(params *GetHomeDashboardParams, opts ...ClientOption) (*GetHomeDashboardOK, error)
 
 	ImportDashboard(params *ImportDashboardParams, opts ...ClientOption) (*ImportDashboardOK, error)
 
@@ -173,7 +175,11 @@ func (a *Client) GetDashboardByUID(params *GetDashboardByUIDParams, opts ...Clie
 /*
 GetDashboardTags gets all dashboards tags of an organisation
 */
-func (a *Client) GetDashboardTags(params *GetDashboardTagsParams, opts ...ClientOption) (*GetDashboardTagsOK, error) {
+func (a *Client) GetDashboardTags(opts ...ClientOption) (*GetDashboardTagsOK, error) {
+	return a.GetDashboardTagsWithParams(nil, opts...)
+}
+
+func (a *Client) GetDashboardTagsWithParams(params *GetDashboardTagsParams, opts ...ClientOption) (*GetDashboardTagsOK, error) {
 	if params == nil {
 		params = NewGetDashboardTagsParams()
 	}
@@ -212,7 +218,11 @@ func (a *Client) GetDashboardTags(params *GetDashboardTagsParams, opts ...Client
 /*
 GetHomeDashboard gets home dashboard
 */
-func (a *Client) GetHomeDashboard(params *GetHomeDashboardParams, opts ...ClientOption) (*GetHomeDashboardOK, error) {
+func (a *Client) GetHomeDashboard(opts ...ClientOption) (*GetHomeDashboardOK, error) {
+	return a.GetHomeDashboardWithParams(nil, opts...)
+}
+
+func (a *Client) GetHomeDashboardWithParams(params *GetHomeDashboardParams, opts ...ClientOption) (*GetHomeDashboardOK, error) {
 	if params == nil {
 		params = NewGetHomeDashboardParams()
 	}

--- a/client/datasources/datasources_client.go
+++ b/client/datasources/datasources_client.go
@@ -66,7 +66,8 @@ type ClientService interface {
 
 	GetDataSourceIDByName(params *GetDataSourceIDByNameParams, opts ...ClientOption) (*GetDataSourceIDByNameOK, error)
 
-	GetDataSources(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error)
+	GetDataSources(opts ...ClientOption) (*GetDataSourcesOK, error)
+	GetDataSourcesWithParams(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error)
 
 	UpdateDataSourceByID(params *UpdateDataSourceByIDParams, opts ...ClientOption) (*UpdateDataSourceByIDOK, error)
 
@@ -848,7 +849,11 @@ func (a *Client) GetDataSourceIDByName(params *GetDataSourceIDByNameParams, opts
 
 you need to have a permission with action: `datasources:read` and scope: `datasources:*`.
 */
-func (a *Client) GetDataSources(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error) {
+func (a *Client) GetDataSources(opts ...ClientOption) (*GetDataSourcesOK, error) {
+	return a.GetDataSourcesWithParams(nil, opts...)
+}
+
+func (a *Client) GetDataSourcesWithParams(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error) {
 	if params == nil {
 		params = NewGetDataSourcesParams()
 	}

--- a/client/enterprise/enterprise_client.go
+++ b/client/enterprise/enterprise_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	SearchResult(params *SearchResultParams, opts ...ClientOption) (*SearchResultOK, error)
+	SearchResult(opts ...ClientOption) (*SearchResultOK, error)
+	SearchResultWithParams(params *SearchResultParams, opts ...ClientOption) (*SearchResultOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,7 +44,11 @@ type ClientService interface {
 You need to have a permission with action `teams.roles:read` on scope `teams:*`
 and a permission with action `users.roles:read` on scope `users:*`.
 */
-func (a *Client) SearchResult(params *SearchResultParams, opts ...ClientOption) (*SearchResultOK, error) {
+func (a *Client) SearchResult(opts ...ClientOption) (*SearchResultOK, error) {
+	return a.SearchResultWithParams(nil, opts...)
+}
+
+func (a *Client) SearchResultWithParams(params *SearchResultParams, opts ...ClientOption) (*SearchResultOK, error) {
 	if params == nil {
 		params = NewSearchResultParams()
 	}

--- a/client/get_current_org/get_current_org_client.go
+++ b/client/get_current_org/get_current_org_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetCurrentOrgQuota(params *GetCurrentOrgQuotaParams, opts ...ClientOption) (*GetCurrentOrgQuotaOK, error)
+	GetCurrentOrgQuota(opts ...ClientOption) (*GetCurrentOrgQuotaOK, error)
+	GetCurrentOrgQuotaWithParams(params *GetCurrentOrgQuotaParams, opts ...ClientOption) (*GetCurrentOrgQuotaOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -40,7 +41,11 @@ GetCurrentOrgQuota fetches organization quota
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `orgs.quotas:read` and scope `org:id:1` (orgIDScope).
 */
-func (a *Client) GetCurrentOrgQuota(params *GetCurrentOrgQuotaParams, opts ...ClientOption) (*GetCurrentOrgQuotaOK, error) {
+func (a *Client) GetCurrentOrgQuota(opts ...ClientOption) (*GetCurrentOrgQuotaOK, error) {
+	return a.GetCurrentOrgQuotaWithParams(nil, opts...)
+}
+
+func (a *Client) GetCurrentOrgQuotaWithParams(params *GetCurrentOrgQuotaParams, opts ...ClientOption) (*GetCurrentOrgQuotaOK, error) {
 	if params == nil {
 		params = NewGetCurrentOrgQuotaParams()
 	}

--- a/client/ldap_debug/ldap_debug_client.go
+++ b/client/ldap_debug/ldap_debug_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetSyncStatus(params *GetSyncStatusParams, opts ...ClientOption) (*GetSyncStatusOK, error)
+	GetSyncStatus(opts ...ClientOption) (*GetSyncStatusOK, error)
+	GetSyncStatusWithParams(params *GetSyncStatusParams, opts ...ClientOption) (*GetSyncStatusOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -40,7 +41,11 @@ GetSyncStatus returns the current state of the LDAP background sync integration
 
 You need to have a permission with action `ldap.status:read`.
 */
-func (a *Client) GetSyncStatus(params *GetSyncStatusParams, opts ...ClientOption) (*GetSyncStatusOK, error) {
+func (a *Client) GetSyncStatus(opts ...ClientOption) (*GetSyncStatusOK, error) {
+	return a.GetSyncStatusWithParams(nil, opts...)
+}
+
+func (a *Client) GetSyncStatusWithParams(params *GetSyncStatusParams, opts ...ClientOption) (*GetSyncStatusOK, error) {
 	if params == nil {
 		params = NewGetSyncStatusParams()
 	}

--- a/client/legacy_alerts_notification_channels/legacy_alerts_notification_channels_client.go
+++ b/client/legacy_alerts_notification_channels/legacy_alerts_notification_channels_client.go
@@ -40,9 +40,11 @@ type ClientService interface {
 
 	GetAlertNotificationChannelByUID(params *GetAlertNotificationChannelByUIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error)
 
-	GetAlertNotificationChannels(params *GetAlertNotificationChannelsParams, opts ...ClientOption) (*GetAlertNotificationChannelsOK, error)
+	GetAlertNotificationChannels(opts ...ClientOption) (*GetAlertNotificationChannelsOK, error)
+	GetAlertNotificationChannelsWithParams(params *GetAlertNotificationChannelsParams, opts ...ClientOption) (*GetAlertNotificationChannelsOK, error)
 
-	GetAlertNotificationLookup(params *GetAlertNotificationLookupParams, opts ...ClientOption) (*GetAlertNotificationLookupOK, error)
+	GetAlertNotificationLookup(opts ...ClientOption) (*GetAlertNotificationLookupOK, error)
+	GetAlertNotificationLookupWithParams(params *GetAlertNotificationLookupParams, opts ...ClientOption) (*GetAlertNotificationLookupOK, error)
 
 	NotificationChannelTest(params *NotificationChannelTestParams, opts ...ClientOption) (*NotificationChannelTestOK, error)
 
@@ -263,7 +265,11 @@ GetAlertNotificationChannels gets all notification channels
 
 Returns all notification channels that the authenticated user has permission to view.
 */
-func (a *Client) GetAlertNotificationChannels(params *GetAlertNotificationChannelsParams, opts ...ClientOption) (*GetAlertNotificationChannelsOK, error) {
+func (a *Client) GetAlertNotificationChannels(opts ...ClientOption) (*GetAlertNotificationChannelsOK, error) {
+	return a.GetAlertNotificationChannelsWithParams(nil, opts...)
+}
+
+func (a *Client) GetAlertNotificationChannelsWithParams(params *GetAlertNotificationChannelsParams, opts ...ClientOption) (*GetAlertNotificationChannelsOK, error) {
 	if params == nil {
 		params = NewGetAlertNotificationChannelsParams()
 	}
@@ -304,7 +310,11 @@ GetAlertNotificationLookup gets all notification channels lookup
 
 Returns all notification channels, but with less detailed information. Accessible by any authenticated user and is mainly used by providing alert notification channels in Grafana UI when configuring alert rule.
 */
-func (a *Client) GetAlertNotificationLookup(params *GetAlertNotificationLookupParams, opts ...ClientOption) (*GetAlertNotificationLookupOK, error) {
+func (a *Client) GetAlertNotificationLookup(opts ...ClientOption) (*GetAlertNotificationLookupOK, error) {
+	return a.GetAlertNotificationLookupWithParams(nil, opts...)
+}
+
+func (a *Client) GetAlertNotificationLookupWithParams(params *GetAlertNotificationLookupParams, opts ...ClientOption) (*GetAlertNotificationLookupOK, error) {
 	if params == nil {
 		params = NewGetAlertNotificationLookupParams()
 	}

--- a/client/licensing/licensing_client.go
+++ b/client/licensing/licensing_client.go
@@ -32,19 +32,24 @@ type ClientOption func(*runtime.ClientOperation)
 type ClientService interface {
 	DeleteLicenseToken(params *DeleteLicenseTokenParams, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error)
 
-	GetCustomPermissionsCSV(params *GetCustomPermissionsCSVParams, opts ...ClientOption) (*GetCustomPermissionsCSVOK, error)
+	GetCustomPermissionsCSV(opts ...ClientOption) (*GetCustomPermissionsCSVOK, error)
+	GetCustomPermissionsCSVWithParams(params *GetCustomPermissionsCSVParams, opts ...ClientOption) (*GetCustomPermissionsCSVOK, error)
 
-	GetCustomPermissionsReport(params *GetCustomPermissionsReportParams, opts ...ClientOption) (*GetCustomPermissionsReportOK, error)
+	GetCustomPermissionsReport(opts ...ClientOption) (*GetCustomPermissionsReportOK, error)
+	GetCustomPermissionsReportWithParams(params *GetCustomPermissionsReportParams, opts ...ClientOption) (*GetCustomPermissionsReportOK, error)
 
-	GetLicenseToken(params *GetLicenseTokenParams, opts ...ClientOption) (*GetLicenseTokenOK, error)
+	GetLicenseToken(opts ...ClientOption) (*GetLicenseTokenOK, error)
+	GetLicenseTokenWithParams(params *GetLicenseTokenParams, opts ...ClientOption) (*GetLicenseTokenOK, error)
 
-	GetStatus(params *GetStatusParams, opts ...ClientOption) (*GetStatusOK, error)
+	GetStatus(opts ...ClientOption) (*GetStatusOK, error)
+	GetStatusWithParams(params *GetStatusParams, opts ...ClientOption) (*GetStatusOK, error)
 
 	PostLicenseToken(params *PostLicenseTokenParams, opts ...ClientOption) (*PostLicenseTokenOK, error)
 
 	PostRenewLicenseToken(params *PostRenewLicenseTokenParams, opts ...ClientOption) (*PostRenewLicenseTokenOK, error)
 
-	RefreshLicenseStats(params *RefreshLicenseStatsParams, opts ...ClientOption) (*RefreshLicenseStatsOK, error)
+	RefreshLicenseStats(opts ...ClientOption) (*RefreshLicenseStatsOK, error)
+	RefreshLicenseStatsWithParams(params *RefreshLicenseStatsParams, opts ...ClientOption) (*RefreshLicenseStatsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -97,7 +102,11 @@ GetCustomPermissionsCSV gets custom permissions report in CSV format
 
 You need to have a permission with action `licensing.reports:read`.
 */
-func (a *Client) GetCustomPermissionsCSV(params *GetCustomPermissionsCSVParams, opts ...ClientOption) (*GetCustomPermissionsCSVOK, error) {
+func (a *Client) GetCustomPermissionsCSV(opts ...ClientOption) (*GetCustomPermissionsCSVOK, error) {
+	return a.GetCustomPermissionsCSVWithParams(nil, opts...)
+}
+
+func (a *Client) GetCustomPermissionsCSVWithParams(params *GetCustomPermissionsCSVParams, opts ...ClientOption) (*GetCustomPermissionsCSVOK, error) {
 	if params == nil {
 		params = NewGetCustomPermissionsCSVParams()
 	}
@@ -138,7 +147,11 @@ GetCustomPermissionsReport gets custom permissions report
 
 You need to have a permission with action `licensing.reports:read`.
 */
-func (a *Client) GetCustomPermissionsReport(params *GetCustomPermissionsReportParams, opts ...ClientOption) (*GetCustomPermissionsReportOK, error) {
+func (a *Client) GetCustomPermissionsReport(opts ...ClientOption) (*GetCustomPermissionsReportOK, error) {
+	return a.GetCustomPermissionsReportWithParams(nil, opts...)
+}
+
+func (a *Client) GetCustomPermissionsReportWithParams(params *GetCustomPermissionsReportParams, opts ...ClientOption) (*GetCustomPermissionsReportOK, error) {
 	if params == nil {
 		params = NewGetCustomPermissionsReportParams()
 	}
@@ -179,7 +192,11 @@ GetLicenseToken gets license token
 
 You need to have a permission with action `licensing:read`.
 */
-func (a *Client) GetLicenseToken(params *GetLicenseTokenParams, opts ...ClientOption) (*GetLicenseTokenOK, error) {
+func (a *Client) GetLicenseToken(opts ...ClientOption) (*GetLicenseTokenOK, error) {
+	return a.GetLicenseTokenWithParams(nil, opts...)
+}
+
+func (a *Client) GetLicenseTokenWithParams(params *GetLicenseTokenParams, opts ...ClientOption) (*GetLicenseTokenOK, error) {
 	if params == nil {
 		params = NewGetLicenseTokenParams()
 	}
@@ -218,7 +235,11 @@ func (a *Client) GetLicenseToken(params *GetLicenseTokenParams, opts ...ClientOp
 /*
 GetStatus checks license availability
 */
-func (a *Client) GetStatus(params *GetStatusParams, opts ...ClientOption) (*GetStatusOK, error) {
+func (a *Client) GetStatus(opts ...ClientOption) (*GetStatusOK, error) {
+	return a.GetStatusWithParams(nil, opts...)
+}
+
+func (a *Client) GetStatusWithParams(params *GetStatusParams, opts ...ClientOption) (*GetStatusOK, error) {
 	if params == nil {
 		params = NewGetStatusParams()
 	}
@@ -343,7 +364,11 @@ RefreshLicenseStats refreshes license stats
 
 You need to have a permission with action `licensing:read`.
 */
-func (a *Client) RefreshLicenseStats(params *RefreshLicenseStatsParams, opts ...ClientOption) (*RefreshLicenseStatsOK, error) {
+func (a *Client) RefreshLicenseStats(opts ...ClientOption) (*RefreshLicenseStatsOK, error) {
+	return a.RefreshLicenseStatsWithParams(nil, opts...)
+}
+
+func (a *Client) RefreshLicenseStatsWithParams(params *RefreshLicenseStatsParams, opts ...ClientOption) (*RefreshLicenseStatsOK, error) {
 	if params == nil {
 		params = NewRefreshLicenseStatsParams()
 	}

--- a/client/org/org_client.go
+++ b/client/org/org_client.go
@@ -32,9 +32,11 @@ type ClientOption func(*runtime.ClientOperation)
 type ClientService interface {
 	AddOrgUserToCurrentOrg(params *AddOrgUserToCurrentOrgParams, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error)
 
-	GetCurrentOrg(params *GetCurrentOrgParams, opts ...ClientOption) (*GetCurrentOrgOK, error)
+	GetCurrentOrg(opts ...ClientOption) (*GetCurrentOrgOK, error)
+	GetCurrentOrgWithParams(params *GetCurrentOrgParams, opts ...ClientOption) (*GetCurrentOrgOK, error)
 
-	GetOrgUsersForCurrentOrg(params *GetOrgUsersForCurrentOrgParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error)
+	GetOrgUsersForCurrentOrg(opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error)
+	GetOrgUsersForCurrentOrgWithParams(params *GetOrgUsersForCurrentOrgParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error)
 
 	GetOrgUsersForCurrentOrgLookup(params *GetOrgUsersForCurrentOrgLookupParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgLookupOK, error)
 
@@ -96,7 +98,11 @@ func (a *Client) AddOrgUserToCurrentOrg(params *AddOrgUserToCurrentOrgParams, op
 /*
 GetCurrentOrg gets current organization
 */
-func (a *Client) GetCurrentOrg(params *GetCurrentOrgParams, opts ...ClientOption) (*GetCurrentOrgOK, error) {
+func (a *Client) GetCurrentOrg(opts ...ClientOption) (*GetCurrentOrgOK, error) {
+	return a.GetCurrentOrgWithParams(nil, opts...)
+}
+
+func (a *Client) GetCurrentOrgWithParams(params *GetCurrentOrgParams, opts ...ClientOption) (*GetCurrentOrgOK, error) {
 	if params == nil {
 		params = NewGetCurrentOrgParams()
 	}
@@ -140,7 +146,11 @@ func (a *Client) GetCurrentOrg(params *GetCurrentOrgParams, opts ...ClientOption
 If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:read` with scope `users:*`.
 */
-func (a *Client) GetOrgUsersForCurrentOrg(params *GetOrgUsersForCurrentOrgParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error) {
+func (a *Client) GetOrgUsersForCurrentOrg(opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error) {
+	return a.GetOrgUsersForCurrentOrgWithParams(nil, opts...)
+}
+
+func (a *Client) GetOrgUsersForCurrentOrgWithParams(params *GetOrgUsersForCurrentOrgParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error) {
 	if params == nil {
 		params = NewGetOrgUsersForCurrentOrgParams()
 	}

--- a/client/org_invites/org_invites_client.go
+++ b/client/org_invites/org_invites_client.go
@@ -32,7 +32,8 @@ type ClientOption func(*runtime.ClientOperation)
 type ClientService interface {
 	AddOrgInvite(params *AddOrgInviteParams, opts ...ClientOption) (*AddOrgInviteOK, error)
 
-	GetPendingOrgInvites(params *GetPendingOrgInvitesParams, opts ...ClientOption) (*GetPendingOrgInvitesOK, error)
+	GetPendingOrgInvites(opts ...ClientOption) (*GetPendingOrgInvitesOK, error)
+	GetPendingOrgInvitesWithParams(params *GetPendingOrgInvitesParams, opts ...ClientOption) (*GetPendingOrgInvitesOK, error)
 
 	RevokeInvite(params *RevokeInviteParams, opts ...ClientOption) (*RevokeInviteOK, error)
 
@@ -81,7 +82,11 @@ func (a *Client) AddOrgInvite(params *AddOrgInviteParams, opts ...ClientOption) 
 /*
 GetPendingOrgInvites gets pending invites
 */
-func (a *Client) GetPendingOrgInvites(params *GetPendingOrgInvitesParams, opts ...ClientOption) (*GetPendingOrgInvitesOK, error) {
+func (a *Client) GetPendingOrgInvites(opts ...ClientOption) (*GetPendingOrgInvitesOK, error) {
+	return a.GetPendingOrgInvitesWithParams(nil, opts...)
+}
+
+func (a *Client) GetPendingOrgInvitesWithParams(params *GetPendingOrgInvitesParams, opts ...ClientOption) (*GetPendingOrgInvitesOK, error) {
 	if params == nil {
 		params = NewGetPendingOrgInvitesParams()
 	}

--- a/client/org_preferences/org_preferences_client.go
+++ b/client/org_preferences/org_preferences_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetOrgPreferences(params *GetOrgPreferencesParams, opts ...ClientOption) (*GetOrgPreferencesOK, error)
+	GetOrgPreferences(opts ...ClientOption) (*GetOrgPreferencesOK, error)
+	GetOrgPreferencesWithParams(params *GetOrgPreferencesParams, opts ...ClientOption) (*GetOrgPreferencesOK, error)
 
 	PatchOrgPreferences(params *PatchOrgPreferencesParams, opts ...ClientOption) (*PatchOrgPreferencesOK, error)
 
@@ -42,7 +43,11 @@ type ClientService interface {
 /*
 GetOrgPreferences gets current org prefs
 */
-func (a *Client) GetOrgPreferences(params *GetOrgPreferencesParams, opts ...ClientOption) (*GetOrgPreferencesOK, error) {
+func (a *Client) GetOrgPreferences(opts ...ClientOption) (*GetOrgPreferencesOK, error) {
+	return a.GetOrgPreferencesWithParams(nil, opts...)
+}
+
+func (a *Client) GetOrgPreferencesWithParams(params *GetOrgPreferencesParams, opts ...ClientOption) (*GetOrgPreferencesOK, error) {
 	if params == nil {
 		params = NewGetOrgPreferencesParams()
 	}

--- a/client/provisioning/provisioning_client.go
+++ b/client/provisioning/provisioning_client.go
@@ -46,7 +46,8 @@ type ClientService interface {
 
 	GetAlertRuleGroupExport(params *GetAlertRuleGroupExportParams, opts ...ClientOption) (*GetAlertRuleGroupExportOK, error)
 
-	GetAlertRules(params *GetAlertRulesParams, opts ...ClientOption) (*GetAlertRulesOK, error)
+	GetAlertRules(opts ...ClientOption) (*GetAlertRulesOK, error)
+	GetAlertRulesWithParams(params *GetAlertRulesParams, opts ...ClientOption) (*GetAlertRulesOK, error)
 
 	GetAlertRulesExport(params *GetAlertRulesExportParams, opts ...ClientOption) (*GetAlertRulesExportOK, error)
 
@@ -56,15 +57,19 @@ type ClientService interface {
 
 	GetMuteTiming(params *GetMuteTimingParams, opts ...ClientOption) (*GetMuteTimingOK, error)
 
-	GetMuteTimings(params *GetMuteTimingsParams, opts ...ClientOption) (*GetMuteTimingsOK, error)
+	GetMuteTimings(opts ...ClientOption) (*GetMuteTimingsOK, error)
+	GetMuteTimingsWithParams(params *GetMuteTimingsParams, opts ...ClientOption) (*GetMuteTimingsOK, error)
 
-	GetPolicyTree(params *GetPolicyTreeParams, opts ...ClientOption) (*GetPolicyTreeOK, error)
+	GetPolicyTree(opts ...ClientOption) (*GetPolicyTreeOK, error)
+	GetPolicyTreeWithParams(params *GetPolicyTreeParams, opts ...ClientOption) (*GetPolicyTreeOK, error)
 
-	GetPolicyTreeExport(params *GetPolicyTreeExportParams, opts ...ClientOption) (*GetPolicyTreeExportOK, error)
+	GetPolicyTreeExport(opts ...ClientOption) (*GetPolicyTreeExportOK, error)
+	GetPolicyTreeExportWithParams(params *GetPolicyTreeExportParams, opts ...ClientOption) (*GetPolicyTreeExportOK, error)
 
 	GetTemplate(params *GetTemplateParams, opts ...ClientOption) (*GetTemplateOK, error)
 
-	GetTemplates(params *GetTemplatesParams, opts ...ClientOption) (*GetTemplatesOK, error)
+	GetTemplates(opts ...ClientOption) (*GetTemplatesOK, error)
+	GetTemplatesWithParams(params *GetTemplatesParams, opts ...ClientOption) (*GetTemplatesOK, error)
 
 	PostAlertRule(params *PostAlertRuleParams, opts ...ClientOption) (*PostAlertRuleCreated, error)
 
@@ -84,7 +89,8 @@ type ClientService interface {
 
 	PutTemplate(params *PutTemplateParams, opts ...ClientOption) (*PutTemplateAccepted, error)
 
-	ResetPolicyTree(params *ResetPolicyTreeParams, opts ...ClientOption) (*ResetPolicyTreeAccepted, error)
+	ResetPolicyTree(opts ...ClientOption) (*ResetPolicyTreeAccepted, error)
+	ResetPolicyTreeWithParams(params *ResetPolicyTreeParams, opts ...ClientOption) (*ResetPolicyTreeAccepted, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -404,7 +410,11 @@ func (a *Client) GetAlertRuleGroupExport(params *GetAlertRuleGroupExportParams, 
 /*
 GetAlertRules gets all the alert rules
 */
-func (a *Client) GetAlertRules(params *GetAlertRulesParams, opts ...ClientOption) (*GetAlertRulesOK, error) {
+func (a *Client) GetAlertRules(opts ...ClientOption) (*GetAlertRulesOK, error) {
+	return a.GetAlertRulesWithParams(nil, opts...)
+}
+
+func (a *Client) GetAlertRulesWithParams(params *GetAlertRulesParams, opts ...ClientOption) (*GetAlertRulesOK, error) {
 	if params == nil {
 		params = NewGetAlertRulesParams()
 	}
@@ -599,7 +609,11 @@ func (a *Client) GetMuteTiming(params *GetMuteTimingParams, opts ...ClientOption
 /*
 GetMuteTimings gets all the mute timings
 */
-func (a *Client) GetMuteTimings(params *GetMuteTimingsParams, opts ...ClientOption) (*GetMuteTimingsOK, error) {
+func (a *Client) GetMuteTimings(opts ...ClientOption) (*GetMuteTimingsOK, error) {
+	return a.GetMuteTimingsWithParams(nil, opts...)
+}
+
+func (a *Client) GetMuteTimingsWithParams(params *GetMuteTimingsParams, opts ...ClientOption) (*GetMuteTimingsOK, error) {
 	if params == nil {
 		params = NewGetMuteTimingsParams()
 	}
@@ -638,7 +652,11 @@ func (a *Client) GetMuteTimings(params *GetMuteTimingsParams, opts ...ClientOpti
 /*
 GetPolicyTree gets the notification policy tree
 */
-func (a *Client) GetPolicyTree(params *GetPolicyTreeParams, opts ...ClientOption) (*GetPolicyTreeOK, error) {
+func (a *Client) GetPolicyTree(opts ...ClientOption) (*GetPolicyTreeOK, error) {
+	return a.GetPolicyTreeWithParams(nil, opts...)
+}
+
+func (a *Client) GetPolicyTreeWithParams(params *GetPolicyTreeParams, opts ...ClientOption) (*GetPolicyTreeOK, error) {
 	if params == nil {
 		params = NewGetPolicyTreeParams()
 	}
@@ -677,7 +695,11 @@ func (a *Client) GetPolicyTree(params *GetPolicyTreeParams, opts ...ClientOption
 /*
 GetPolicyTreeExport exports the notification policy tree in provisioning file format
 */
-func (a *Client) GetPolicyTreeExport(params *GetPolicyTreeExportParams, opts ...ClientOption) (*GetPolicyTreeExportOK, error) {
+func (a *Client) GetPolicyTreeExport(opts ...ClientOption) (*GetPolicyTreeExportOK, error) {
+	return a.GetPolicyTreeExportWithParams(nil, opts...)
+}
+
+func (a *Client) GetPolicyTreeExportWithParams(params *GetPolicyTreeExportParams, opts ...ClientOption) (*GetPolicyTreeExportOK, error) {
 	if params == nil {
 		params = NewGetPolicyTreeExportParams()
 	}
@@ -755,7 +777,11 @@ func (a *Client) GetTemplate(params *GetTemplateParams, opts ...ClientOption) (*
 /*
 GetTemplates gets all notification templates
 */
-func (a *Client) GetTemplates(params *GetTemplatesParams, opts ...ClientOption) (*GetTemplatesOK, error) {
+func (a *Client) GetTemplates(opts ...ClientOption) (*GetTemplatesOK, error) {
+	return a.GetTemplatesWithParams(nil, opts...)
+}
+
+func (a *Client) GetTemplatesWithParams(params *GetTemplatesParams, opts ...ClientOption) (*GetTemplatesOK, error) {
 	if params == nil {
 		params = NewGetTemplatesParams()
 	}
@@ -1145,7 +1171,11 @@ func (a *Client) PutTemplate(params *PutTemplateParams, opts ...ClientOption) (*
 /*
 ResetPolicyTree clears the notification policy tree
 */
-func (a *Client) ResetPolicyTree(params *ResetPolicyTreeParams, opts ...ClientOption) (*ResetPolicyTreeAccepted, error) {
+func (a *Client) ResetPolicyTree(opts ...ClientOption) (*ResetPolicyTreeAccepted, error) {
+	return a.ResetPolicyTreeWithParams(nil, opts...)
+}
+
+func (a *Client) ResetPolicyTreeWithParams(params *ResetPolicyTreeParams, opts ...ClientOption) (*ResetPolicyTreeAccepted, error) {
 	if params == nil {
 		params = NewResetPolicyTreeParams()
 	}

--- a/client/recording_rules/recording_rules_client.go
+++ b/client/recording_rules/recording_rules_client.go
@@ -36,11 +36,14 @@ type ClientService interface {
 
 	DeleteRecordingRule(params *DeleteRecordingRuleParams, opts ...ClientOption) (*DeleteRecordingRuleOK, error)
 
-	DeleteRecordingRuleWriteTarget(params *DeleteRecordingRuleWriteTargetParams, opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error)
+	DeleteRecordingRuleWriteTarget(opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error)
+	DeleteRecordingRuleWriteTargetWithParams(params *DeleteRecordingRuleWriteTargetParams, opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error)
 
-	GetRecordingRuleWriteTarget(params *GetRecordingRuleWriteTargetParams, opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error)
+	GetRecordingRuleWriteTarget(opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error)
+	GetRecordingRuleWriteTargetWithParams(params *GetRecordingRuleWriteTargetParams, opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error)
 
-	ListRecordingRules(params *ListRecordingRulesParams, opts ...ClientOption) (*ListRecordingRulesOK, error)
+	ListRecordingRules(opts ...ClientOption) (*ListRecordingRulesOK, error)
+	ListRecordingRulesWithParams(params *ListRecordingRulesParams, opts ...ClientOption) (*ListRecordingRulesOK, error)
 
 	TestCreateRecordingRule(params *TestCreateRecordingRuleParams, opts ...ClientOption) (*TestCreateRecordingRuleOK, error)
 
@@ -171,7 +174,11 @@ func (a *Client) DeleteRecordingRule(params *DeleteRecordingRuleParams, opts ...
 /*
 DeleteRecordingRuleWriteTarget deletes the remote write target
 */
-func (a *Client) DeleteRecordingRuleWriteTarget(params *DeleteRecordingRuleWriteTargetParams, opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error) {
+func (a *Client) DeleteRecordingRuleWriteTarget(opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error) {
+	return a.DeleteRecordingRuleWriteTargetWithParams(nil, opts...)
+}
+
+func (a *Client) DeleteRecordingRuleWriteTargetWithParams(params *DeleteRecordingRuleWriteTargetParams, opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error) {
 	if params == nil {
 		params = NewDeleteRecordingRuleWriteTargetParams()
 	}
@@ -210,7 +217,11 @@ func (a *Client) DeleteRecordingRuleWriteTarget(params *DeleteRecordingRuleWrite
 /*
 GetRecordingRuleWriteTarget returns the prometheus remote write target
 */
-func (a *Client) GetRecordingRuleWriteTarget(params *GetRecordingRuleWriteTargetParams, opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error) {
+func (a *Client) GetRecordingRuleWriteTarget(opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error) {
+	return a.GetRecordingRuleWriteTargetWithParams(nil, opts...)
+}
+
+func (a *Client) GetRecordingRuleWriteTargetWithParams(params *GetRecordingRuleWriteTargetParams, opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error) {
 	if params == nil {
 		params = NewGetRecordingRuleWriteTargetParams()
 	}
@@ -249,7 +260,11 @@ func (a *Client) GetRecordingRuleWriteTarget(params *GetRecordingRuleWriteTarget
 /*
 ListRecordingRules lists all rules in the database active or deleted
 */
-func (a *Client) ListRecordingRules(params *ListRecordingRulesParams, opts ...ClientOption) (*ListRecordingRulesOK, error) {
+func (a *Client) ListRecordingRules(opts ...ClientOption) (*ListRecordingRulesOK, error) {
+	return a.ListRecordingRulesWithParams(nil, opts...)
+}
+
+func (a *Client) ListRecordingRulesWithParams(params *ListRecordingRulesParams, opts ...ClientOption) (*ListRecordingRulesOK, error) {
 	if params == nil {
 		params = NewListRecordingRulesParams()
 	}

--- a/client/reports/reports_client.go
+++ b/client/reports/reports_client.go
@@ -36,9 +36,11 @@ type ClientService interface {
 
 	GetReport(params *GetReportParams, opts ...ClientOption) (*GetReportOK, error)
 
-	GetReportSettings(params *GetReportSettingsParams, opts ...ClientOption) (*GetReportSettingsOK, error)
+	GetReportSettings(opts ...ClientOption) (*GetReportSettingsOK, error)
+	GetReportSettingsWithParams(params *GetReportSettingsParams, opts ...ClientOption) (*GetReportSettingsOK, error)
 
-	GetReports(params *GetReportsParams, opts ...ClientOption) (*GetReportsOK, error)
+	GetReports(opts ...ClientOption) (*GetReportsOK, error)
+	GetReportsWithParams(params *GetReportsParams, opts ...ClientOption) (*GetReportsOK, error)
 
 	RenderReportPDF(params *RenderReportPDFParams, opts ...ClientOption) (*RenderReportPDFOK, error)
 
@@ -191,7 +193,11 @@ func (a *Client) GetReport(params *GetReportParams, opts ...ClientOption) (*GetR
 
 You need to have a permission with action `reports.settings:read`x.
 */
-func (a *Client) GetReportSettings(params *GetReportSettingsParams, opts ...ClientOption) (*GetReportSettingsOK, error) {
+func (a *Client) GetReportSettings(opts ...ClientOption) (*GetReportSettingsOK, error) {
+	return a.GetReportSettingsWithParams(nil, opts...)
+}
+
+func (a *Client) GetReportSettingsWithParams(params *GetReportSettingsParams, opts ...ClientOption) (*GetReportSettingsOK, error) {
 	if params == nil {
 		params = NewGetReportSettingsParams()
 	}
@@ -234,7 +240,11 @@ func (a *Client) GetReportSettings(params *GetReportSettingsParams, opts ...Clie
 
 You need to have a permission with action `reports:read` with scope `reports:*`.
 */
-func (a *Client) GetReports(params *GetReportsParams, opts ...ClientOption) (*GetReportsOK, error) {
+func (a *Client) GetReports(opts ...ClientOption) (*GetReportsOK, error) {
+	return a.GetReportsWithParams(nil, opts...)
+}
+
+func (a *Client) GetReportsWithParams(params *GetReportsParams, opts ...ClientOption) (*GetReportsOK, error) {
 	if params == nil {
 		params = NewGetReportsParams()
 	}

--- a/client/saml/saml_client.go
+++ b/client/saml/saml_client.go
@@ -30,11 +30,14 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetMetadata(params *GetMetadataParams, opts ...ClientOption) (*GetMetadataOK, error)
+	GetMetadata(opts ...ClientOption) (*GetMetadataOK, error)
+	GetMetadataWithParams(params *GetMetadataParams, opts ...ClientOption) (*GetMetadataOK, error)
 
-	GetSAMLLogout(params *GetSAMLLogoutParams, opts ...ClientOption) error
+	GetSAMLLogout(opts ...ClientOption) error
+	GetSAMLLogoutWithParams(params *GetSAMLLogoutParams, opts ...ClientOption) error
 
-	GetSLO(params *GetSLOParams, opts ...ClientOption) error
+	GetSLO(opts ...ClientOption) error
+	GetSLOWithParams(params *GetSLOParams, opts ...ClientOption) error
 
 	PostACS(params *PostACSParams, opts ...ClientOption) error
 
@@ -46,7 +49,11 @@ type ClientService interface {
 /*
 GetMetadata its exposes the s p grafana s metadata for the Id p s consumption
 */
-func (a *Client) GetMetadata(params *GetMetadataParams, opts ...ClientOption) (*GetMetadataOK, error) {
+func (a *Client) GetMetadata(opts ...ClientOption) (*GetMetadataOK, error) {
+	return a.GetMetadataWithParams(nil, opts...)
+}
+
+func (a *Client) GetMetadataWithParams(params *GetMetadataParams, opts ...ClientOption) (*GetMetadataOK, error) {
 	if params == nil {
 		params = NewGetMetadataParams()
 	}
@@ -85,7 +92,11 @@ func (a *Client) GetMetadata(params *GetMetadataParams, opts ...ClientOption) (*
 /*
 GetSAMLLogout gets logout initiates single logout process
 */
-func (a *Client) GetSAMLLogout(params *GetSAMLLogoutParams, opts ...ClientOption) error {
+func (a *Client) GetSAMLLogout(opts ...ClientOption) error {
+	return a.GetSAMLLogoutWithParams(nil, opts...)
+}
+
+func (a *Client) GetSAMLLogoutWithParams(params *GetSAMLLogoutParams, opts ...ClientOption) error {
 	if params == nil {
 		params = NewGetSAMLLogoutParams()
 	}
@@ -123,7 +134,11 @@ func (a *Client) GetSAMLLogout(params *GetSAMLLogoutParams, opts ...ClientOption
 2. Logout request when another SP initiates single logout and IdP sends logout request to the Grafana,
 or in case of IdP-initiated logout.
 */
-func (a *Client) GetSLO(params *GetSLOParams, opts ...ClientOption) error {
+func (a *Client) GetSLO(opts ...ClientOption) error {
+	return a.GetSLOWithParams(nil, opts...)
+}
+
+func (a *Client) GetSLOWithParams(params *GetSLOParams, opts ...ClientOption) error {
 	if params == nil {
 		params = NewGetSLOParams()
 	}

--- a/client/search/search_client.go
+++ b/client/search/search_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	ListSortOptions(params *ListSortOptionsParams, opts ...ClientOption) (*ListSortOptionsOK, error)
+	ListSortOptions(opts ...ClientOption) (*ListSortOptionsOK, error)
+	ListSortOptionsWithParams(params *ListSortOptionsParams, opts ...ClientOption) (*ListSortOptionsOK, error)
 
 	Search(params *SearchParams, opts ...ClientOption) (*SearchOK, error)
 
@@ -40,7 +41,11 @@ type ClientService interface {
 /*
 ListSortOptions lists search sorting options
 */
-func (a *Client) ListSortOptions(params *ListSortOptionsParams, opts ...ClientOption) (*ListSortOptionsOK, error) {
+func (a *Client) ListSortOptions(opts ...ClientOption) (*ListSortOptionsOK, error) {
+	return a.ListSortOptionsWithParams(nil, opts...)
+}
+
+func (a *Client) ListSortOptionsWithParams(params *ListSortOptionsParams, opts ...ClientOption) (*ListSortOptionsOK, error) {
 	if params == nil {
 		params = NewListSortOptionsParams()
 	}

--- a/client/signed_in_user/signed_in_user_client.go
+++ b/client/signed_in_user/signed_in_user_client.go
@@ -32,17 +32,23 @@ type ClientOption func(*runtime.ClientOperation)
 type ClientService interface {
 	ChangeUserPassword(params *ChangeUserPasswordParams, opts ...ClientOption) (*ChangeUserPasswordOK, error)
 
-	ClearHelpFlags(params *ClearHelpFlagsParams, opts ...ClientOption) (*ClearHelpFlagsOK, error)
+	ClearHelpFlags(opts ...ClientOption) (*ClearHelpFlagsOK, error)
+	ClearHelpFlagsWithParams(params *ClearHelpFlagsParams, opts ...ClientOption) (*ClearHelpFlagsOK, error)
 
-	GetSignedInUser(params *GetSignedInUserParams, opts ...ClientOption) (*GetSignedInUserOK, error)
+	GetSignedInUser(opts ...ClientOption) (*GetSignedInUserOK, error)
+	GetSignedInUserWithParams(params *GetSignedInUserParams, opts ...ClientOption) (*GetSignedInUserOK, error)
 
-	GetSignedInUserOrgList(params *GetSignedInUserOrgListParams, opts ...ClientOption) (*GetSignedInUserOrgListOK, error)
+	GetSignedInUserOrgList(opts ...ClientOption) (*GetSignedInUserOrgListOK, error)
+	GetSignedInUserOrgListWithParams(params *GetSignedInUserOrgListParams, opts ...ClientOption) (*GetSignedInUserOrgListOK, error)
 
-	GetSignedInUserTeamList(params *GetSignedInUserTeamListParams, opts ...ClientOption) (*GetSignedInUserTeamListOK, error)
+	GetSignedInUserTeamList(opts ...ClientOption) (*GetSignedInUserTeamListOK, error)
+	GetSignedInUserTeamListWithParams(params *GetSignedInUserTeamListParams, opts ...ClientOption) (*GetSignedInUserTeamListOK, error)
 
-	GetUserAuthTokens(params *GetUserAuthTokensParams, opts ...ClientOption) (*GetUserAuthTokensOK, error)
+	GetUserAuthTokens(opts ...ClientOption) (*GetUserAuthTokensOK, error)
+	GetUserAuthTokensWithParams(params *GetUserAuthTokensParams, opts ...ClientOption) (*GetUserAuthTokensOK, error)
 
-	GetUserQuotas(params *GetUserQuotasParams, opts ...ClientOption) (*GetUserQuotasOK, error)
+	GetUserQuotas(opts ...ClientOption) (*GetUserQuotasOK, error)
+	GetUserQuotasWithParams(params *GetUserQuotasParams, opts ...ClientOption) (*GetUserQuotasOK, error)
 
 	RevokeUserAuthToken(params *RevokeUserAuthTokenParams, opts ...ClientOption) (*RevokeUserAuthTokenOK, error)
 
@@ -107,7 +113,11 @@ func (a *Client) ChangeUserPassword(params *ChangeUserPasswordParams, opts ...Cl
 /*
 ClearHelpFlags clears user help flag
 */
-func (a *Client) ClearHelpFlags(params *ClearHelpFlagsParams, opts ...ClientOption) (*ClearHelpFlagsOK, error) {
+func (a *Client) ClearHelpFlags(opts ...ClientOption) (*ClearHelpFlagsOK, error) {
+	return a.ClearHelpFlagsWithParams(nil, opts...)
+}
+
+func (a *Client) ClearHelpFlagsWithParams(params *ClearHelpFlagsParams, opts ...ClientOption) (*ClearHelpFlagsOK, error) {
 	if params == nil {
 		params = NewClearHelpFlagsParams()
 	}
@@ -146,7 +156,11 @@ func (a *Client) ClearHelpFlags(params *ClearHelpFlagsParams, opts ...ClientOpti
 /*
 GetSignedInUser Get (current authenticated user)
 */
-func (a *Client) GetSignedInUser(params *GetSignedInUserParams, opts ...ClientOption) (*GetSignedInUserOK, error) {
+func (a *Client) GetSignedInUser(opts ...ClientOption) (*GetSignedInUserOK, error) {
+	return a.GetSignedInUserWithParams(nil, opts...)
+}
+
+func (a *Client) GetSignedInUserWithParams(params *GetSignedInUserParams, opts ...ClientOption) (*GetSignedInUserOK, error) {
 	if params == nil {
 		params = NewGetSignedInUserParams()
 	}
@@ -187,7 +201,11 @@ GetSignedInUserOrgList organizations of the actual user
 
 Return a list of all organizations of the current user.
 */
-func (a *Client) GetSignedInUserOrgList(params *GetSignedInUserOrgListParams, opts ...ClientOption) (*GetSignedInUserOrgListOK, error) {
+func (a *Client) GetSignedInUserOrgList(opts ...ClientOption) (*GetSignedInUserOrgListOK, error) {
+	return a.GetSignedInUserOrgListWithParams(nil, opts...)
+}
+
+func (a *Client) GetSignedInUserOrgListWithParams(params *GetSignedInUserOrgListParams, opts ...ClientOption) (*GetSignedInUserOrgListOK, error) {
 	if params == nil {
 		params = NewGetSignedInUserOrgListParams()
 	}
@@ -228,7 +246,11 @@ GetSignedInUserTeamList teams that the actual user is member of
 
 Return a list of all teams that the current user is member of.
 */
-func (a *Client) GetSignedInUserTeamList(params *GetSignedInUserTeamListParams, opts ...ClientOption) (*GetSignedInUserTeamListOK, error) {
+func (a *Client) GetSignedInUserTeamList(opts ...ClientOption) (*GetSignedInUserTeamListOK, error) {
+	return a.GetSignedInUserTeamListWithParams(nil, opts...)
+}
+
+func (a *Client) GetSignedInUserTeamListWithParams(params *GetSignedInUserTeamListParams, opts ...ClientOption) (*GetSignedInUserTeamListOK, error) {
 	if params == nil {
 		params = NewGetSignedInUserTeamListParams()
 	}
@@ -269,7 +291,11 @@ GetUserAuthTokens auths tokens of the actual user
 
 Return a list of all auth tokens (devices) that the actual user currently have logged in from.
 */
-func (a *Client) GetUserAuthTokens(params *GetUserAuthTokensParams, opts ...ClientOption) (*GetUserAuthTokensOK, error) {
+func (a *Client) GetUserAuthTokens(opts ...ClientOption) (*GetUserAuthTokensOK, error) {
+	return a.GetUserAuthTokensWithParams(nil, opts...)
+}
+
+func (a *Client) GetUserAuthTokensWithParams(params *GetUserAuthTokensParams, opts ...ClientOption) (*GetUserAuthTokensOK, error) {
 	if params == nil {
 		params = NewGetUserAuthTokensParams()
 	}
@@ -308,7 +334,11 @@ func (a *Client) GetUserAuthTokens(params *GetUserAuthTokensParams, opts ...Clie
 /*
 GetUserQuotas fetches user quota
 */
-func (a *Client) GetUserQuotas(params *GetUserQuotasParams, opts ...ClientOption) (*GetUserQuotasOK, error) {
+func (a *Client) GetUserQuotas(opts ...ClientOption) (*GetUserQuotasOK, error) {
+	return a.GetUserQuotasWithParams(nil, opts...)
+}
+
+func (a *Client) GetUserQuotasWithParams(params *GetUserQuotasParams, opts ...ClientOption) (*GetUserQuotasOK, error) {
 	if params == nil {
 		params = NewGetUserQuotasParams()
 	}

--- a/client/snapshots/snapshots_client.go
+++ b/client/snapshots/snapshots_client.go
@@ -38,7 +38,8 @@ type ClientService interface {
 
 	GetDashboardSnapshot(params *GetDashboardSnapshotParams, opts ...ClientOption) (*GetDashboardSnapshotOK, error)
 
-	GetSharingOptions(params *GetSharingOptionsParams, opts ...ClientOption) (*GetSharingOptionsOK, error)
+	GetSharingOptions(opts ...ClientOption) (*GetSharingOptionsOK, error)
+	GetSharingOptionsWithParams(params *GetSharingOptionsParams, opts ...ClientOption) (*GetSharingOptionsOK, error)
 
 	SearchDashboardSnapshots(params *SearchDashboardSnapshotsParams, opts ...ClientOption) (*SearchDashboardSnapshotsOK, error)
 
@@ -208,7 +209,11 @@ func (a *Client) GetDashboardSnapshot(params *GetDashboardSnapshotParams, opts .
 /*
 GetSharingOptions gets snapshot sharing settings
 */
-func (a *Client) GetSharingOptions(params *GetSharingOptionsParams, opts ...ClientOption) (*GetSharingOptionsOK, error) {
+func (a *Client) GetSharingOptions(opts ...ClientOption) (*GetSharingOptionsOK, error) {
+	return a.GetSharingOptionsWithParams(nil, opts...)
+}
+
+func (a *Client) GetSharingOptionsWithParams(params *GetSharingOptionsParams, opts ...ClientOption) (*GetSharingOptionsOK, error) {
 	if params == nil {
 		params = NewGetSharingOptionsParams()
 	}

--- a/client/user_preferences/user_preferences_client.go
+++ b/client/user_preferences/user_preferences_client.go
@@ -30,7 +30,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetUserPreferences(params *GetUserPreferencesParams, opts ...ClientOption) (*GetUserPreferencesOK, error)
+	GetUserPreferences(opts ...ClientOption) (*GetUserPreferencesOK, error)
+	GetUserPreferencesWithParams(params *GetUserPreferencesParams, opts ...ClientOption) (*GetUserPreferencesOK, error)
 
 	PatchUserPreferences(params *PatchUserPreferencesParams, opts ...ClientOption) (*PatchUserPreferencesOK, error)
 
@@ -42,7 +43,11 @@ type ClientService interface {
 /*
 GetUserPreferences gets user preferences
 */
-func (a *Client) GetUserPreferences(params *GetUserPreferencesParams, opts ...ClientOption) (*GetUserPreferencesOK, error) {
+func (a *Client) GetUserPreferences(opts ...ClientOption) (*GetUserPreferencesOK, error) {
+	return a.GetUserPreferencesWithParams(nil, opts...)
+}
+
+func (a *Client) GetUserPreferencesWithParams(params *GetUserPreferencesParams, opts ...ClientOption) (*GetUserPreferencesOK, error) {
 	if params == nil {
 		params = NewGetUserPreferencesParams()
 	}

--- a/client/users/users_client.go
+++ b/client/users/users_client.go
@@ -40,7 +40,8 @@ type ClientService interface {
 
 	SearchUsers(params *SearchUsersParams, opts ...ClientOption) (*SearchUsersOK, error)
 
-	SearchUsersWithPaging(params *SearchUsersWithPagingParams, opts ...ClientOption) (*SearchUsersWithPagingOK, error)
+	SearchUsersWithPaging(opts ...ClientOption) (*SearchUsersWithPagingOK, error)
+	SearchUsersWithPagingWithParams(params *SearchUsersWithPagingParams, opts ...ClientOption) (*SearchUsersWithPagingOK, error)
 
 	UpdateUser(params *UpdateUserParams, opts ...ClientOption) (*UpdateUserOK, error)
 
@@ -251,7 +252,11 @@ func (a *Client) SearchUsers(params *SearchUsersParams, opts ...ClientOption) (*
 /*
 SearchUsersWithPaging gets users with paging
 */
-func (a *Client) SearchUsersWithPaging(params *SearchUsersWithPagingParams, opts ...ClientOption) (*SearchUsersWithPagingOK, error) {
+func (a *Client) SearchUsersWithPaging(opts ...ClientOption) (*SearchUsersWithPagingOK, error) {
+	return a.SearchUsersWithPagingWithParams(nil, opts...)
+}
+
+func (a *Client) SearchUsersWithPagingWithParams(params *SearchUsersWithPagingParams, opts ...ClientOption) (*SearchUsersWithPagingOK, error) {
 	if params == nil {
 		params = NewSearchUsersWithPagingParams()
 	}

--- a/models/route.go
+++ b/models/route.go
@@ -72,6 +72,10 @@ func (m *Route) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateObjectMatchers(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateProvenance(formats); err != nil {
 		res = append(res, err)
 	}
@@ -115,6 +119,23 @@ func (m *Route) validateMatchers(formats strfmt.Registry) error {
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *Route) validateObjectMatchers(formats strfmt.Registry) error {
+	if swag.IsZero(m.ObjectMatchers) { // not required
+		return nil
+	}
+
+	if err := m.ObjectMatchers.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("object_matchers")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}
@@ -177,6 +198,10 @@ func (m *Route) ContextValidate(ctx context.Context, formats strfmt.Registry) er
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateObjectMatchers(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateProvenance(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -216,6 +241,20 @@ func (m *Route) contextValidateMatchers(ctx context.Context, formats strfmt.Regi
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *Route) contextValidateObjectMatchers(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.ObjectMatchers.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("object_matchers")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}

--- a/models/route_export.go
+++ b/models/route_export.go
@@ -69,6 +69,10 @@ func (m *RouteExport) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateObjectMatchers(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateRoutes(formats); err != nil {
 		res = append(res, err)
 	}
@@ -115,6 +119,23 @@ func (m *RouteExport) validateMatchers(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *RouteExport) validateObjectMatchers(formats strfmt.Registry) error {
+	if swag.IsZero(m.ObjectMatchers) { // not required
+		return nil
+	}
+
+	if err := m.ObjectMatchers.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("object_matchers")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("object_matchers")
+		}
+		return err
+	}
+
+	return nil
+}
+
 func (m *RouteExport) validateRoutes(formats strfmt.Registry) error {
 	if swag.IsZero(m.Routes) { // not required
 		return nil
@@ -153,6 +174,10 @@ func (m *RouteExport) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateObjectMatchers(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateRoutes(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -188,6 +213,20 @@ func (m *RouteExport) contextValidateMatchers(ctx context.Context, formats strfm
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *RouteExport) contextValidateObjectMatchers(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.ObjectMatchers.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("object_matchers")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}

--- a/templates/clientClient.gotmpl
+++ b/templates/clientClient.gotmpl
@@ -45,7 +45,15 @@ type ClientOption func(*runtime.ClientOperation)
 // ClientService is the interface for Client methods
 type ClientService interface {
 	{{ range .Operations }}
+
+  {{/* META COMMENT: If there are no required params by default, remove params as a default argument and add another function (WithParams) if users want to specify longform params */}}
+  {{ if not .Params }}
+	{{ pascalize .Name }}({{ if .HasStreamingResponse }}writer io.Writer, {{ end }}opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
+	{{ pascalize .Name }}WithParams(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
+  {{ else }}
 	{{ pascalize .Name }}(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
+  {{ end }}
+
 	{{ end }}
 
 	SetTransport(transport runtime.ClientTransport)
@@ -57,7 +65,15 @@ type ClientService interface {
 
   {{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}{{ humanize .Name }} API{{ end }}
 */
+{{- if not .Params }}
+func (a *Client) {{ pascalize .Name }}({{ if .HasStreamingResponse }}writer io.Writer, {{ end }}opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
+  return a.{{ pascalize .Name }}WithParams(nil{{ if .HasStreamingResponse }}, writer{{ end }}, opts...)
+}
+
+func (a *Client) {{ pascalize .Name }}WithParams(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
+{{- else }}
 func (a *Client) {{ pascalize .Name }}(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
+{{- end }}
   if params == nil {
     params = New{{ pascalize .Name }}Params()
   }


### PR DESCRIPTION
For example, some list API calls dont have any query or path params at all. It's a bit annoying to have to pass an empty xxxParams object for no reason 

For users wanting to use advanced params features like context and timeout, also add a `WithParams` function that allows the params to be used as before

Next up: Operations that require only one param will be simplified as well (ex: GetFolderByUID shouldn't require a whole params argument, just a uid param)