### PR TITLE
Usability improvement: Simply operations with one or two params

### DIFF
--- a/client/access_control/access_control_client.go
+++ b/client/access_control/access_control_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new access control API client.
@@ -30,38 +32,50 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddTeamRole(params *AddTeamRoleParams, opts ...ClientOption) (*AddTeamRoleOK, error)
+	AddTeamRole(teamID int64, body *models.AddTeamRoleCommand, opts ...ClientOption) (*AddTeamRoleOK, error)
+	AddTeamRoleWithParams(params *AddTeamRoleParams, opts ...ClientOption) (*AddTeamRoleOK, error)
 
-	AddUserRole(params *AddUserRoleParams, opts ...ClientOption) (*AddUserRoleOK, error)
+	AddUserRole(userID int64, body *models.AddUserRoleCommand, opts ...ClientOption) (*AddUserRoleOK, error)
+	AddUserRoleWithParams(params *AddUserRoleParams, opts ...ClientOption) (*AddUserRoleOK, error)
 
-	CreateRole(params *CreateRoleParams, opts ...ClientOption) (*CreateRoleCreated, error)
+	CreateRole(body *models.CreateRoleForm, opts ...ClientOption) (*CreateRoleCreated, error)
+	CreateRoleWithParams(params *CreateRoleParams, opts ...ClientOption) (*CreateRoleCreated, error)
 
 	DeleteRole(params *DeleteRoleParams, opts ...ClientOption) (*DeleteRoleOK, error)
 
 	GetAccessControlStatus(opts ...ClientOption) (*GetAccessControlStatusOK, error)
 	GetAccessControlStatusWithParams(params *GetAccessControlStatusParams, opts ...ClientOption) (*GetAccessControlStatusOK, error)
 
-	GetRole(params *GetRoleParams, opts ...ClientOption) (*GetRoleOK, error)
+	GetRole(roleUID string, opts ...ClientOption) (*GetRoleOK, error)
+	GetRoleWithParams(params *GetRoleParams, opts ...ClientOption) (*GetRoleOK, error)
 
-	GetRoleAssignments(params *GetRoleAssignmentsParams, opts ...ClientOption) (*GetRoleAssignmentsOK, error)
+	GetRoleAssignments(roleUID string, opts ...ClientOption) (*GetRoleAssignmentsOK, error)
+	GetRoleAssignmentsWithParams(params *GetRoleAssignmentsParams, opts ...ClientOption) (*GetRoleAssignmentsOK, error)
 
 	ListRoles(params *ListRolesParams, opts ...ClientOption) (*ListRolesOK, error)
 
-	ListTeamRoles(params *ListTeamRolesParams, opts ...ClientOption) (*ListTeamRolesOK, error)
+	ListTeamRoles(teamID int64, opts ...ClientOption) (*ListTeamRolesOK, error)
+	ListTeamRolesWithParams(params *ListTeamRolesParams, opts ...ClientOption) (*ListTeamRolesOK, error)
 
-	ListUserRoles(params *ListUserRolesParams, opts ...ClientOption) (*ListUserRolesOK, error)
+	ListUserRoles(userID int64, opts ...ClientOption) (*ListUserRolesOK, error)
+	ListUserRolesWithParams(params *ListUserRolesParams, opts ...ClientOption) (*ListUserRolesOK, error)
 
-	RemoveTeamRole(params *RemoveTeamRoleParams, opts ...ClientOption) (*RemoveTeamRoleOK, error)
+	RemoveTeamRole(teamID int64, roleUID string, opts ...ClientOption) (*RemoveTeamRoleOK, error)
+	RemoveTeamRoleWithParams(params *RemoveTeamRoleParams, opts ...ClientOption) (*RemoveTeamRoleOK, error)
 
 	RemoveUserRole(params *RemoveUserRoleParams, opts ...ClientOption) (*RemoveUserRoleOK, error)
 
-	SetRoleAssignments(params *SetRoleAssignmentsParams, opts ...ClientOption) (*SetRoleAssignmentsOK, error)
+	SetRoleAssignments(roleUID string, body *models.SetRoleAssignmentsCommand, opts ...ClientOption) (*SetRoleAssignmentsOK, error)
+	SetRoleAssignmentsWithParams(params *SetRoleAssignmentsParams, opts ...ClientOption) (*SetRoleAssignmentsOK, error)
 
-	SetTeamRoles(params *SetTeamRolesParams, opts ...ClientOption) (*SetTeamRolesOK, error)
+	SetTeamRoles(teamID int64, opts ...ClientOption) (*SetTeamRolesOK, error)
+	SetTeamRolesWithParams(params *SetTeamRolesParams, opts ...ClientOption) (*SetTeamRolesOK, error)
 
-	SetUserRoles(params *SetUserRolesParams, opts ...ClientOption) (*SetUserRolesOK, error)
+	SetUserRoles(userID int64, body *models.SetUserRolesCommand, opts ...ClientOption) (*SetUserRolesOK, error)
+	SetUserRolesWithParams(params *SetUserRolesParams, opts ...ClientOption) (*SetUserRolesOK, error)
 
-	UpdateRole(params *UpdateRoleParams, opts ...ClientOption) (*UpdateRoleOK, error)
+	UpdateRole(roleUID string, body *models.UpdateRoleCommand, opts ...ClientOption) (*UpdateRoleOK, error)
+	UpdateRoleWithParams(params *UpdateRoleParams, opts ...ClientOption) (*UpdateRoleOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -71,7 +85,12 @@ AddTeamRole adds team role
 
 You need to have a permission with action `teams.roles:add` and scope `permissions:type:delegate`.
 */
-func (a *Client) AddTeamRole(params *AddTeamRoleParams, opts ...ClientOption) (*AddTeamRoleOK, error) {
+func (a *Client) AddTeamRole(teamID int64, body *models.AddTeamRoleCommand, opts ...ClientOption) (*AddTeamRoleOK, error) {
+	params := NewAddTeamRoleParams().WithBody(body).WithTeamID(teamID)
+	return a.AddTeamRoleWithParams(params, opts...)
+}
+
+func (a *Client) AddTeamRoleWithParams(params *AddTeamRoleParams, opts ...ClientOption) (*AddTeamRoleOK, error) {
 	if params == nil {
 		params = NewAddTeamRoleParams()
 	}
@@ -108,13 +127,18 @@ func (a *Client) AddTeamRole(params *AddTeamRoleParams, opts ...ClientOption) (*
 }
 
 /*
-	AddUserRole adds a user role assignment
+AddUserRole adds a user role assignment
 
-	Assign a role to a specific user. For bulk updates consider Set user role assignments.
+Assign a role to a specific user. For bulk updates consider Set user role assignments.
 
 You need to have a permission with action `users.roles:add` and scope `permissions:type:delegate`. `permissions:type:delegate` scope ensures that users can only assign roles which have same, or a subset of permissions which the user has. For example, if a user does not have required permissions for creating users, they won’t be able to assign a role which will allow to do that. This is done to prevent escalation of privileges.
 */
-func (a *Client) AddUserRole(params *AddUserRoleParams, opts ...ClientOption) (*AddUserRoleOK, error) {
+func (a *Client) AddUserRole(userID int64, body *models.AddUserRoleCommand, opts ...ClientOption) (*AddUserRoleOK, error) {
+	params := NewAddUserRoleParams().WithBody(body).WithUserID(userID)
+	return a.AddUserRoleWithParams(params, opts...)
+}
+
+func (a *Client) AddUserRoleWithParams(params *AddUserRoleParams, opts ...ClientOption) (*AddUserRoleOK, error) {
 	if params == nil {
 		params = NewAddUserRoleParams()
 	}
@@ -151,14 +175,19 @@ func (a *Client) AddUserRole(params *AddUserRoleParams, opts ...ClientOption) (*
 }
 
 /*
-	CreateRole creates a new custom role
+CreateRole creates a new custom role
 
-	Creates a new custom role and maps given permissions to that role. Note that roles with the same prefix as Fixed Roles can’t be created.
+Creates a new custom role and maps given permissions to that role. Note that roles with the same prefix as Fixed Roles can’t be created.
 
 You need to have a permission with action `roles:write` and scope `permissions:type:delegate`. `permissions:type:delegate` scope ensures that users can only create custom roles with the same, or a subset of permissions which the user has.
 For example, if a user does not have required permissions for creating users, they won’t be able to create a custom role which allows to do that. This is done to prevent escalation of privileges.
 */
-func (a *Client) CreateRole(params *CreateRoleParams, opts ...ClientOption) (*CreateRoleCreated, error) {
+func (a *Client) CreateRole(body *models.CreateRoleForm, opts ...ClientOption) (*CreateRoleCreated, error) {
+	params := NewCreateRoleParams().WithBody(body)
+	return a.CreateRoleWithParams(params, opts...)
+}
+
+func (a *Client) CreateRoleWithParams(params *CreateRoleParams, opts ...ClientOption) (*CreateRoleCreated, error) {
 	if params == nil {
 		params = NewCreateRoleParams()
 	}
@@ -195,12 +224,13 @@ func (a *Client) CreateRole(params *CreateRoleParams, opts ...ClientOption) (*Cr
 }
 
 /*
-	DeleteRole deletes a custom role
+DeleteRole deletes a custom role
 
-	Delete a role with the given UID, and it’s permissions. If the role is assigned to a built-in role, the deletion operation will fail, unless force query param is set to true, and in that case all assignments will also be deleted.
+Delete a role with the given UID, and it’s permissions. If the role is assigned to a built-in role, the deletion operation will fail, unless force query param is set to true, and in that case all assignments will also be deleted.
 
 You need to have a permission with action `roles:delete` and scope `permissions:type:delegate`. `permissions:type:delegate` scope ensures that users can only delete a custom role with the same, or a subset of permissions which the user has. For example, if a user does not have required permissions for creating users, they won’t be able to delete a custom role which allows to do that.
 */
+
 func (a *Client) DeleteRole(params *DeleteRoleParams, opts ...ClientOption) (*DeleteRoleOK, error) {
 	if params == nil {
 		params = NewDeleteRoleParams()
@@ -238,14 +268,15 @@ func (a *Client) DeleteRole(params *DeleteRoleParams, opts ...ClientOption) (*De
 }
 
 /*
-	GetAccessControlStatus gets status
+GetAccessControlStatus gets status
 
-	Returns an indicator to check if fine-grained access control is enabled or not.
+Returns an indicator to check if fine-grained access control is enabled or not.
 
 You need to have a permission with action `status:accesscontrol` and scope `services:accesscontrol`.
 */
 func (a *Client) GetAccessControlStatus(opts ...ClientOption) (*GetAccessControlStatusOK, error) {
-	return a.GetAccessControlStatusWithParams(nil, opts...)
+	params := NewGetAccessControlStatusParams()
+	return a.GetAccessControlStatusWithParams(params, opts...)
 }
 
 func (a *Client) GetAccessControlStatusWithParams(params *GetAccessControlStatusParams, opts ...ClientOption) (*GetAccessControlStatusOK, error) {
@@ -285,13 +316,18 @@ func (a *Client) GetAccessControlStatusWithParams(params *GetAccessControlStatus
 }
 
 /*
-	GetRole gets a role
+GetRole gets a role
 
-	Get a role for the given UID.
+Get a role for the given UID.
 
 You need to have a permission with action `roles:read` and scope `roles:*`.
 */
-func (a *Client) GetRole(params *GetRoleParams, opts ...ClientOption) (*GetRoleOK, error) {
+func (a *Client) GetRole(roleUID string, opts ...ClientOption) (*GetRoleOK, error) {
+	params := NewGetRoleParams().WithRoleUID(roleUID)
+	return a.GetRoleWithParams(params, opts...)
+}
+
+func (a *Client) GetRoleWithParams(params *GetRoleParams, opts ...ClientOption) (*GetRoleOK, error) {
 	if params == nil {
 		params = NewGetRoleParams()
 	}
@@ -328,13 +364,18 @@ func (a *Client) GetRole(params *GetRoleParams, opts ...ClientOption) (*GetRoleO
 }
 
 /*
-	GetRoleAssignments gets role assignments
+GetRoleAssignments gets role assignments
 
-	Get role assignments for the role with the given UID.
+Get role assignments for the role with the given UID.
 
 You need to have a permission with action `teams.roles:list` and scope `teams:id:*` and `users.roles:list` and scope `users:id:*`.
 */
-func (a *Client) GetRoleAssignments(params *GetRoleAssignmentsParams, opts ...ClientOption) (*GetRoleAssignmentsOK, error) {
+func (a *Client) GetRoleAssignments(roleUID string, opts ...ClientOption) (*GetRoleAssignmentsOK, error) {
+	params := NewGetRoleAssignmentsParams().WithRoleUID(roleUID)
+	return a.GetRoleAssignmentsWithParams(params, opts...)
+}
+
+func (a *Client) GetRoleAssignmentsWithParams(params *GetRoleAssignmentsParams, opts ...ClientOption) (*GetRoleAssignmentsOK, error) {
 	if params == nil {
 		params = NewGetRoleAssignmentsParams()
 	}
@@ -371,12 +412,13 @@ func (a *Client) GetRoleAssignments(params *GetRoleAssignmentsParams, opts ...Cl
 }
 
 /*
-	ListRoles gets all roles
+ListRoles gets all roles
 
-	Gets all existing roles. The response contains all global and organization local roles, for the organization which user is signed in.
+Gets all existing roles. The response contains all global and organization local roles, for the organization which user is signed in.
 
 You need to have a permission with action `roles:read` and scope `roles:*`.
 */
+
 func (a *Client) ListRoles(params *ListRolesParams, opts ...ClientOption) (*ListRolesOK, error) {
 	if params == nil {
 		params = NewListRolesParams()
@@ -418,7 +460,12 @@ ListTeamRoles gets team roles
 
 You need to have a permission with action `teams.roles:read` and scope `teams:id:<team ID>`.
 */
-func (a *Client) ListTeamRoles(params *ListTeamRolesParams, opts ...ClientOption) (*ListTeamRolesOK, error) {
+func (a *Client) ListTeamRoles(teamID int64, opts ...ClientOption) (*ListTeamRolesOK, error) {
+	params := NewListTeamRolesParams().WithTeamID(teamID)
+	return a.ListTeamRolesWithParams(params, opts...)
+}
+
+func (a *Client) ListTeamRolesWithParams(params *ListTeamRolesParams, opts ...ClientOption) (*ListTeamRolesOK, error) {
 	if params == nil {
 		params = NewListTeamRolesParams()
 	}
@@ -455,13 +502,18 @@ func (a *Client) ListTeamRoles(params *ListTeamRolesParams, opts ...ClientOption
 }
 
 /*
-	ListUserRoles lists roles assigned to a user
+ListUserRoles lists roles assigned to a user
 
-	Lists the roles that have been directly assigned to a given user. The list does not include built-in roles (Viewer, Editor, Admin or Grafana Admin), and it does not include roles that have been inherited from a team.
+Lists the roles that have been directly assigned to a given user. The list does not include built-in roles (Viewer, Editor, Admin or Grafana Admin), and it does not include roles that have been inherited from a team.
 
 You need to have a permission with action `users.roles:read` and scope `users:id:<user ID>`.
 */
-func (a *Client) ListUserRoles(params *ListUserRolesParams, opts ...ClientOption) (*ListUserRolesOK, error) {
+func (a *Client) ListUserRoles(userID int64, opts ...ClientOption) (*ListUserRolesOK, error) {
+	params := NewListUserRolesParams().WithUserID(userID)
+	return a.ListUserRolesWithParams(params, opts...)
+}
+
+func (a *Client) ListUserRolesWithParams(params *ListUserRolesParams, opts ...ClientOption) (*ListUserRolesOK, error) {
 	if params == nil {
 		params = NewListUserRolesParams()
 	}
@@ -502,7 +554,12 @@ RemoveTeamRole removes team role
 
 You need to have a permission with action `teams.roles:remove` and scope `permissions:type:delegate`.
 */
-func (a *Client) RemoveTeamRole(params *RemoveTeamRoleParams, opts ...ClientOption) (*RemoveTeamRoleOK, error) {
+func (a *Client) RemoveTeamRole(teamID int64, roleUID string, opts ...ClientOption) (*RemoveTeamRoleOK, error) {
+	params := NewRemoveTeamRoleParams().WithRoleUID(roleUID).WithTeamID(teamID)
+	return a.RemoveTeamRoleWithParams(params, opts...)
+}
+
+func (a *Client) RemoveTeamRoleWithParams(params *RemoveTeamRoleParams, opts ...ClientOption) (*RemoveTeamRoleOK, error) {
 	if params == nil {
 		params = NewRemoveTeamRoleParams()
 	}
@@ -539,12 +596,13 @@ func (a *Client) RemoveTeamRole(params *RemoveTeamRoleParams, opts ...ClientOpti
 }
 
 /*
-	RemoveUserRole removes a user role assignment
+RemoveUserRole removes a user role assignment
 
-	Revoke a role from a user. For bulk updates consider Set user role assignments.
+Revoke a role from a user. For bulk updates consider Set user role assignments.
 
 You need to have a permission with action `users.roles:remove` and scope `permissions:type:delegate`. `permissions:type:delegate` scope ensures that users can only unassign roles which have same, or a subset of permissions which the user has. For example, if a user does not have required permissions for creating users, they won’t be able to unassign a role which will allow to do that. This is done to prevent escalation of privileges.
 */
+
 func (a *Client) RemoveUserRole(params *RemoveUserRoleParams, opts ...ClientOption) (*RemoveUserRoleOK, error) {
 	if params == nil {
 		params = NewRemoveUserRoleParams()
@@ -582,13 +640,18 @@ func (a *Client) RemoveUserRole(params *RemoveUserRoleParams, opts ...ClientOpti
 }
 
 /*
-	SetRoleAssignments sets role assignments
+SetRoleAssignments sets role assignments
 
-	Set role assignments for the role with the given UID.
+Set role assignments for the role with the given UID.
 
 You need to have a permission with action `teams.roles:add` and `teams.roles:remove` and scope `permissions:type:delegate`, and `users.roles:add` and `users.roles:remove` and scope `permissions:type:delegate`.
 */
-func (a *Client) SetRoleAssignments(params *SetRoleAssignmentsParams, opts ...ClientOption) (*SetRoleAssignmentsOK, error) {
+func (a *Client) SetRoleAssignments(roleUID string, body *models.SetRoleAssignmentsCommand, opts ...ClientOption) (*SetRoleAssignmentsOK, error) {
+	params := NewSetRoleAssignmentsParams().WithBody(body).WithRoleUID(roleUID)
+	return a.SetRoleAssignmentsWithParams(params, opts...)
+}
+
+func (a *Client) SetRoleAssignmentsWithParams(params *SetRoleAssignmentsParams, opts ...ClientOption) (*SetRoleAssignmentsOK, error) {
 	if params == nil {
 		params = NewSetRoleAssignmentsParams()
 	}
@@ -629,7 +692,12 @@ SetTeamRoles updates team role
 
 You need to have a permission with action `teams.roles:add` and `teams.roles:remove` and scope `permissions:type:delegate` for each.
 */
-func (a *Client) SetTeamRoles(params *SetTeamRolesParams, opts ...ClientOption) (*SetTeamRolesOK, error) {
+func (a *Client) SetTeamRoles(teamID int64, opts ...ClientOption) (*SetTeamRolesOK, error) {
+	params := NewSetTeamRolesParams().WithTeamID(teamID)
+	return a.SetTeamRolesWithParams(params, opts...)
+}
+
+func (a *Client) SetTeamRolesWithParams(params *SetTeamRolesParams, opts ...ClientOption) (*SetTeamRolesOK, error) {
 	if params == nil {
 		params = NewSetTeamRolesParams()
 	}
@@ -666,15 +734,19 @@ func (a *Client) SetTeamRoles(params *SetTeamRolesParams, opts ...ClientOption) 
 }
 
 /*
-	SetUserRoles sets user role assignments
+SetUserRoles sets user role assignments
 
-	Update the user’s role assignments to match the provided set of UIDs. This will remove any assigned roles that aren’t in the request and add roles that are in the set but are not already assigned to the user.
-
+Update the user’s role assignments to match the provided set of UIDs. This will remove any assigned roles that aren’t in the request and add roles that are in the set but are not already assigned to the user.
 If you want to add or remove a single role, consider using Add a user role assignment or Remove a user role assignment instead.
 
 You need to have a permission with action `users.roles:add` and `users.roles:remove` and scope `permissions:type:delegate` for each. `permissions:type:delegate`  scope ensures that users can only assign or unassign roles which have same, or a subset of permissions which the user has. For example, if a user does not have required permissions for creating users, they won’t be able to assign or unassign a role which will allow to do that. This is done to prevent escalation of privileges.
 */
-func (a *Client) SetUserRoles(params *SetUserRolesParams, opts ...ClientOption) (*SetUserRolesOK, error) {
+func (a *Client) SetUserRoles(userID int64, body *models.SetUserRolesCommand, opts ...ClientOption) (*SetUserRolesOK, error) {
+	params := NewSetUserRolesParams().WithBody(body).WithUserID(userID)
+	return a.SetUserRolesWithParams(params, opts...)
+}
+
+func (a *Client) SetUserRolesWithParams(params *SetUserRolesParams, opts ...ClientOption) (*SetUserRolesOK, error) {
 	if params == nil {
 		params = NewSetUserRolesParams()
 	}
@@ -715,7 +787,12 @@ UpdateRole updates a custom role
 
 You need to have a permission with action `roles:write` and scope `permissions:type:delegate`. `permissions:type:delegate` scope ensures that users can only create custom roles with the same, or a subset of permissions which the user has.
 */
-func (a *Client) UpdateRole(params *UpdateRoleParams, opts ...ClientOption) (*UpdateRoleOK, error) {
+func (a *Client) UpdateRole(roleUID string, body *models.UpdateRoleCommand, opts ...ClientOption) (*UpdateRoleOK, error) {
+	params := NewUpdateRoleParams().WithBody(body).WithRoleUID(roleUID)
+	return a.UpdateRoleWithParams(params, opts...)
+}
+
+func (a *Client) UpdateRoleWithParams(params *UpdateRoleParams, opts ...ClientOption) (*UpdateRoleOK, error) {
 	if params == nil {
 		params = NewUpdateRoleParams()
 	}

--- a/client/access_control_provisioning/access_control_provisioning_client.go
+++ b/client/access_control_provisioning/access_control_provisioning_client.go
@@ -40,7 +40,8 @@ type ClientService interface {
 AdminProvisioningReloadAccessControl yous need to have a permission with action provisioning reload with scope provisioners accesscontrol
 */
 func (a *Client) AdminProvisioningReloadAccessControl(opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error) {
-	return a.AdminProvisioningReloadAccessControlWithParams(nil, opts...)
+	params := NewAdminProvisioningReloadAccessControlParams()
+	return a.AdminProvisioningReloadAccessControlWithParams(params, opts...)
 }
 
 func (a *Client) AdminProvisioningReloadAccessControlWithParams(params *AdminProvisioningReloadAccessControlParams, opts ...ClientOption) (*AdminProvisioningReloadAccessControlAccepted, error) {

--- a/client/admin/admin_client.go
+++ b/client/admin/admin_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new admin API client.
@@ -36,7 +38,8 @@ type ClientService interface {
 	AdminGetStats(opts ...ClientOption) (*AdminGetStatsOK, error)
 	AdminGetStatsWithParams(params *AdminGetStatsParams, opts ...ClientOption) (*AdminGetStatsOK, error)
 
-	PauseAllAlerts(params *PauseAllAlertsParams, opts ...ClientOption) (*PauseAllAlertsOK, error)
+	PauseAllAlerts(body *models.PauseAllAlertsCommand, opts ...ClientOption) (*PauseAllAlertsOK, error)
+	PauseAllAlertsWithParams(params *PauseAllAlertsParams, opts ...ClientOption) (*PauseAllAlertsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -47,7 +50,8 @@ AdminGetSettings fetches settings
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `settings:read` and scopes: `settings:*`, `settings:auth.saml:` and `settings:auth.saml:enabled` (property level).
 */
 func (a *Client) AdminGetSettings(opts ...ClientOption) (*AdminGetSettingsOK, error) {
-	return a.AdminGetSettingsWithParams(nil, opts...)
+	params := NewAdminGetSettingsParams()
+	return a.AdminGetSettingsWithParams(params, opts...)
 }
 
 func (a *Client) AdminGetSettingsWithParams(params *AdminGetSettingsParams, opts ...ClientOption) (*AdminGetSettingsOK, error) {
@@ -87,14 +91,14 @@ func (a *Client) AdminGetSettingsWithParams(params *AdminGetSettingsParams, opts
 }
 
 /*
-	AdminGetStats fetches grafana stats
+AdminGetStats fetches grafana stats
 
-	Only works with Basic Authentication (username and password). See introduction for an explanation.
-
+Only works with Basic Authentication (username and password). See introduction for an explanation.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `server:stats:read`.
 */
 func (a *Client) AdminGetStats(opts ...ClientOption) (*AdminGetStatsOK, error) {
-	return a.AdminGetStatsWithParams(nil, opts...)
+	params := NewAdminGetStatsParams()
+	return a.AdminGetStatsWithParams(params, opts...)
 }
 
 func (a *Client) AdminGetStatsWithParams(params *AdminGetStatsParams, opts ...ClientOption) (*AdminGetStatsOK, error) {
@@ -136,7 +140,12 @@ func (a *Client) AdminGetStatsWithParams(params *AdminGetStatsParams, opts ...Cl
 /*
 PauseAllAlerts pauses unpause all legacy alerts
 */
-func (a *Client) PauseAllAlerts(params *PauseAllAlertsParams, opts ...ClientOption) (*PauseAllAlertsOK, error) {
+func (a *Client) PauseAllAlerts(body *models.PauseAllAlertsCommand, opts ...ClientOption) (*PauseAllAlertsOK, error) {
+	params := NewPauseAllAlertsParams().WithBody(body)
+	return a.PauseAllAlertsWithParams(params, opts...)
+}
+
+func (a *Client) PauseAllAlertsWithParams(params *PauseAllAlertsParams, opts ...ClientOption) (*PauseAllAlertsOK, error) {
 	if params == nil {
 		params = NewPauseAllAlertsParams()
 	}

--- a/client/admin_ldap/admin_ldap_client.go
+++ b/client/admin_ldap/admin_ldap_client.go
@@ -33,9 +33,11 @@ type ClientService interface {
 	GetLDAPStatus(opts ...ClientOption) (*GetLDAPStatusOK, error)
 	GetLDAPStatusWithParams(params *GetLDAPStatusParams, opts ...ClientOption) (*GetLDAPStatusOK, error)
 
-	GetUserFromLDAP(params *GetUserFromLDAPParams, opts ...ClientOption) (*GetUserFromLDAPOK, error)
+	GetUserFromLDAP(userName string, opts ...ClientOption) (*GetUserFromLDAPOK, error)
+	GetUserFromLDAPWithParams(params *GetUserFromLDAPParams, opts ...ClientOption) (*GetUserFromLDAPOK, error)
 
-	PostSyncUserWithLDAP(params *PostSyncUserWithLDAPParams, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error)
+	PostSyncUserWithLDAP(userID int64, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error)
+	PostSyncUserWithLDAPWithParams(params *PostSyncUserWithLDAPParams, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error)
 
 	ReloadLDAPCfg(opts ...ClientOption) (*ReloadLDAPCfgOK, error)
 	ReloadLDAPCfgWithParams(params *ReloadLDAPCfgParams, opts ...ClientOption) (*ReloadLDAPCfgOK, error)
@@ -49,7 +51,8 @@ GetLDAPStatus attempts to connect to all the configured LDAP servers and returns
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `ldap.status:read`.
 */
 func (a *Client) GetLDAPStatus(opts ...ClientOption) (*GetLDAPStatusOK, error) {
-	return a.GetLDAPStatusWithParams(nil, opts...)
+	params := NewGetLDAPStatusParams()
+	return a.GetLDAPStatusWithParams(params, opts...)
 }
 
 func (a *Client) GetLDAPStatusWithParams(params *GetLDAPStatusParams, opts ...ClientOption) (*GetLDAPStatusOK, error) {
@@ -93,7 +96,12 @@ GetUserFromLDAP finds an user based on a username in LDAP this helps illustrate 
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `ldap.user:read`.
 */
-func (a *Client) GetUserFromLDAP(params *GetUserFromLDAPParams, opts ...ClientOption) (*GetUserFromLDAPOK, error) {
+func (a *Client) GetUserFromLDAP(userName string, opts ...ClientOption) (*GetUserFromLDAPOK, error) {
+	params := NewGetUserFromLDAPParams().WithUserName(userName)
+	return a.GetUserFromLDAPWithParams(params, opts...)
+}
+
+func (a *Client) GetUserFromLDAPWithParams(params *GetUserFromLDAPParams, opts ...ClientOption) (*GetUserFromLDAPOK, error) {
 	if params == nil {
 		params = NewGetUserFromLDAPParams()
 	}
@@ -134,7 +142,12 @@ PostSyncUserWithLDAP enables a single grafana user to be synchronized against LD
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `ldap.user:sync`.
 */
-func (a *Client) PostSyncUserWithLDAP(params *PostSyncUserWithLDAPParams, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error) {
+func (a *Client) PostSyncUserWithLDAP(userID int64, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error) {
+	params := NewPostSyncUserWithLDAPParams().WithUserID(userID)
+	return a.PostSyncUserWithLDAPWithParams(params, opts...)
+}
+
+func (a *Client) PostSyncUserWithLDAPWithParams(params *PostSyncUserWithLDAPParams, opts ...ClientOption) (*PostSyncUserWithLDAPOK, error) {
 	if params == nil {
 		params = NewPostSyncUserWithLDAPParams()
 	}
@@ -176,7 +189,8 @@ ReloadLDAPCfg reloads the LDAP configuration
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `ldap.config:reload`.
 */
 func (a *Client) ReloadLDAPCfg(opts ...ClientOption) (*ReloadLDAPCfgOK, error) {
-	return a.ReloadLDAPCfgWithParams(nil, opts...)
+	params := NewReloadLDAPCfgParams()
+	return a.ReloadLDAPCfgWithParams(params, opts...)
 }
 
 func (a *Client) ReloadLDAPCfgWithParams(params *ReloadLDAPCfgParams, opts ...ClientOption) (*ReloadLDAPCfgOK, error) {

--- a/client/admin_provisioning/admin_provisioning_client.go
+++ b/client/admin_provisioning/admin_provisioning_client.go
@@ -46,14 +46,14 @@ type ClientService interface {
 }
 
 /*
-	AdminProvisioningReloadDashboards reloads dashboard provisioning configurations
+AdminProvisioningReloadDashboards reloads dashboard provisioning configurations
 
-	Reloads the provisioning config files for dashboards again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
-
+Reloads the provisioning config files for dashboards again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:dashboards`.
 */
 func (a *Client) AdminProvisioningReloadDashboards(opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error) {
-	return a.AdminProvisioningReloadDashboardsWithParams(nil, opts...)
+	params := NewAdminProvisioningReloadDashboardsParams()
+	return a.AdminProvisioningReloadDashboardsWithParams(params, opts...)
 }
 
 func (a *Client) AdminProvisioningReloadDashboardsWithParams(params *AdminProvisioningReloadDashboardsParams, opts ...ClientOption) (*AdminProvisioningReloadDashboardsOK, error) {
@@ -93,14 +93,14 @@ func (a *Client) AdminProvisioningReloadDashboardsWithParams(params *AdminProvis
 }
 
 /*
-	AdminProvisioningReloadDatasources reloads datasource provisioning configurations
+AdminProvisioningReloadDatasources reloads datasource provisioning configurations
 
-	Reloads the provisioning config files for datasources again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
-
+Reloads the provisioning config files for datasources again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:datasources`.
 */
 func (a *Client) AdminProvisioningReloadDatasources(opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error) {
-	return a.AdminProvisioningReloadDatasourcesWithParams(nil, opts...)
+	params := NewAdminProvisioningReloadDatasourcesParams()
+	return a.AdminProvisioningReloadDatasourcesWithParams(params, opts...)
 }
 
 func (a *Client) AdminProvisioningReloadDatasourcesWithParams(params *AdminProvisioningReloadDatasourcesParams, opts ...ClientOption) (*AdminProvisioningReloadDatasourcesOK, error) {
@@ -140,14 +140,14 @@ func (a *Client) AdminProvisioningReloadDatasourcesWithParams(params *AdminProvi
 }
 
 /*
-	AdminProvisioningReloadNotifications reloads legacy alert notifier provisioning configurations
+AdminProvisioningReloadNotifications reloads legacy alert notifier provisioning configurations
 
-	Reloads the provisioning config files for legacy alert notifiers again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
-
+Reloads the provisioning config files for legacy alert notifiers again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:notifications`.
 */
 func (a *Client) AdminProvisioningReloadNotifications(opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error) {
-	return a.AdminProvisioningReloadNotificationsWithParams(nil, opts...)
+	params := NewAdminProvisioningReloadNotificationsParams()
+	return a.AdminProvisioningReloadNotificationsWithParams(params, opts...)
 }
 
 func (a *Client) AdminProvisioningReloadNotificationsWithParams(params *AdminProvisioningReloadNotificationsParams, opts ...ClientOption) (*AdminProvisioningReloadNotificationsOK, error) {
@@ -187,14 +187,14 @@ func (a *Client) AdminProvisioningReloadNotificationsWithParams(params *AdminPro
 }
 
 /*
-	AdminProvisioningReloadPlugins reloads plugin provisioning configurations
+AdminProvisioningReloadPlugins reloads plugin provisioning configurations
 
-	Reloads the provisioning config files for plugins again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
-
+Reloads the provisioning config files for plugins again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:plugin`.
 */
 func (a *Client) AdminProvisioningReloadPlugins(opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error) {
-	return a.AdminProvisioningReloadPluginsWithParams(nil, opts...)
+	params := NewAdminProvisioningReloadPluginsParams()
+	return a.AdminProvisioningReloadPluginsWithParams(params, opts...)
 }
 
 func (a *Client) AdminProvisioningReloadPluginsWithParams(params *AdminProvisioningReloadPluginsParams, opts ...ClientOption) (*AdminProvisioningReloadPluginsOK, error) {

--- a/client/admin_users/admin_users_client.go
+++ b/client/admin_users/admin_users_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new admin users API client.
@@ -30,25 +32,35 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AdminCreateUser(params *AdminCreateUserParams, opts ...ClientOption) (*AdminCreateUserOK, error)
+	AdminCreateUser(body *models.AdminCreateUserForm, opts ...ClientOption) (*AdminCreateUserOK, error)
+	AdminCreateUserWithParams(params *AdminCreateUserParams, opts ...ClientOption) (*AdminCreateUserOK, error)
 
-	AdminDeleteUser(params *AdminDeleteUserParams, opts ...ClientOption) (*AdminDeleteUserOK, error)
+	AdminDeleteUser(userID int64, opts ...ClientOption) (*AdminDeleteUserOK, error)
+	AdminDeleteUserWithParams(params *AdminDeleteUserParams, opts ...ClientOption) (*AdminDeleteUserOK, error)
 
-	AdminDisableUser(params *AdminDisableUserParams, opts ...ClientOption) (*AdminDisableUserOK, error)
+	AdminDisableUser(userID int64, opts ...ClientOption) (*AdminDisableUserOK, error)
+	AdminDisableUserWithParams(params *AdminDisableUserParams, opts ...ClientOption) (*AdminDisableUserOK, error)
 
-	AdminEnableUser(params *AdminEnableUserParams, opts ...ClientOption) (*AdminEnableUserOK, error)
+	AdminEnableUser(userID int64, opts ...ClientOption) (*AdminEnableUserOK, error)
+	AdminEnableUserWithParams(params *AdminEnableUserParams, opts ...ClientOption) (*AdminEnableUserOK, error)
 
-	AdminGetUserAuthTokens(params *AdminGetUserAuthTokensParams, opts ...ClientOption) (*AdminGetUserAuthTokensOK, error)
+	AdminGetUserAuthTokens(userID int64, opts ...ClientOption) (*AdminGetUserAuthTokensOK, error)
+	AdminGetUserAuthTokensWithParams(params *AdminGetUserAuthTokensParams, opts ...ClientOption) (*AdminGetUserAuthTokensOK, error)
 
-	AdminLogoutUser(params *AdminLogoutUserParams, opts ...ClientOption) (*AdminLogoutUserOK, error)
+	AdminLogoutUser(userID int64, opts ...ClientOption) (*AdminLogoutUserOK, error)
+	AdminLogoutUserWithParams(params *AdminLogoutUserParams, opts ...ClientOption) (*AdminLogoutUserOK, error)
 
-	AdminRevokeUserAuthToken(params *AdminRevokeUserAuthTokenParams, opts ...ClientOption) (*AdminRevokeUserAuthTokenOK, error)
+	AdminRevokeUserAuthToken(userID int64, body *models.RevokeAuthTokenCmd, opts ...ClientOption) (*AdminRevokeUserAuthTokenOK, error)
+	AdminRevokeUserAuthTokenWithParams(params *AdminRevokeUserAuthTokenParams, opts ...ClientOption) (*AdminRevokeUserAuthTokenOK, error)
 
-	AdminUpdateUserPassword(params *AdminUpdateUserPasswordParams, opts ...ClientOption) (*AdminUpdateUserPasswordOK, error)
+	AdminUpdateUserPassword(userID int64, body *models.AdminUpdateUserPasswordForm, opts ...ClientOption) (*AdminUpdateUserPasswordOK, error)
+	AdminUpdateUserPasswordWithParams(params *AdminUpdateUserPasswordParams, opts ...ClientOption) (*AdminUpdateUserPasswordOK, error)
 
-	AdminUpdateUserPermissions(params *AdminUpdateUserPermissionsParams, opts ...ClientOption) (*AdminUpdateUserPermissionsOK, error)
+	AdminUpdateUserPermissions(userID int64, body *models.AdminUpdateUserPermissionsForm, opts ...ClientOption) (*AdminUpdateUserPermissionsOK, error)
+	AdminUpdateUserPermissionsWithParams(params *AdminUpdateUserPermissionsParams, opts ...ClientOption) (*AdminUpdateUserPermissionsOK, error)
 
-	GetUserQuota(params *GetUserQuotaParams, opts ...ClientOption) (*GetUserQuotaOK, error)
+	GetUserQuota(userID int64, opts ...ClientOption) (*GetUserQuotaOK, error)
+	GetUserQuotaWithParams(params *GetUserQuotaParams, opts ...ClientOption) (*GetUserQuotaOK, error)
 
 	UpdateUserQuota(params *UpdateUserQuotaParams, opts ...ClientOption) (*UpdateUserQuotaOK, error)
 
@@ -56,13 +68,17 @@ type ClientService interface {
 }
 
 /*
-	AdminCreateUser creates new user
+AdminCreateUser creates new user
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users:create`.
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users:create`.
 Note that OrgId is an optional parameter that can be used to assign a new user to a different organization when `auto_assign_org` is set to `true`.
 */
-func (a *Client) AdminCreateUser(params *AdminCreateUserParams, opts ...ClientOption) (*AdminCreateUserOK, error) {
+func (a *Client) AdminCreateUser(body *models.AdminCreateUserForm, opts ...ClientOption) (*AdminCreateUserOK, error) {
+	params := NewAdminCreateUserParams().WithBody(body)
+	return a.AdminCreateUserWithParams(params, opts...)
+}
+
+func (a *Client) AdminCreateUserWithParams(params *AdminCreateUserParams, opts ...ClientOption) (*AdminCreateUserOK, error) {
 	if params == nil {
 		params = NewAdminCreateUserParams()
 	}
@@ -103,7 +119,12 @@ AdminDeleteUser deletes global user
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users:delete` and scope `global.users:*`.
 */
-func (a *Client) AdminDeleteUser(params *AdminDeleteUserParams, opts ...ClientOption) (*AdminDeleteUserOK, error) {
+func (a *Client) AdminDeleteUser(userID int64, opts ...ClientOption) (*AdminDeleteUserOK, error) {
+	params := NewAdminDeleteUserParams().WithUserID(userID)
+	return a.AdminDeleteUserWithParams(params, opts...)
+}
+
+func (a *Client) AdminDeleteUserWithParams(params *AdminDeleteUserParams, opts ...ClientOption) (*AdminDeleteUserOK, error) {
 	if params == nil {
 		params = NewAdminDeleteUserParams()
 	}
@@ -144,7 +165,12 @@ AdminDisableUser disables user
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users:disable` and scope `global.users:1` (userIDScope).
 */
-func (a *Client) AdminDisableUser(params *AdminDisableUserParams, opts ...ClientOption) (*AdminDisableUserOK, error) {
+func (a *Client) AdminDisableUser(userID int64, opts ...ClientOption) (*AdminDisableUserOK, error) {
+	params := NewAdminDisableUserParams().WithUserID(userID)
+	return a.AdminDisableUserWithParams(params, opts...)
+}
+
+func (a *Client) AdminDisableUserWithParams(params *AdminDisableUserParams, opts ...ClientOption) (*AdminDisableUserOK, error) {
 	if params == nil {
 		params = NewAdminDisableUserParams()
 	}
@@ -185,7 +211,12 @@ AdminEnableUser enables user
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users:enable` and scope `global.users:1` (userIDScope).
 */
-func (a *Client) AdminEnableUser(params *AdminEnableUserParams, opts ...ClientOption) (*AdminEnableUserOK, error) {
+func (a *Client) AdminEnableUser(userID int64, opts ...ClientOption) (*AdminEnableUserOK, error) {
+	params := NewAdminEnableUserParams().WithUserID(userID)
+	return a.AdminEnableUserWithParams(params, opts...)
+}
+
+func (a *Client) AdminEnableUserWithParams(params *AdminEnableUserParams, opts ...ClientOption) (*AdminEnableUserOK, error) {
 	if params == nil {
 		params = NewAdminEnableUserParams()
 	}
@@ -226,7 +257,12 @@ AdminGetUserAuthTokens returns a list of all auth tokens devices that the user c
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.authtoken:list` and scope `global.users:*`.
 */
-func (a *Client) AdminGetUserAuthTokens(params *AdminGetUserAuthTokensParams, opts ...ClientOption) (*AdminGetUserAuthTokensOK, error) {
+func (a *Client) AdminGetUserAuthTokens(userID int64, opts ...ClientOption) (*AdminGetUserAuthTokensOK, error) {
+	params := NewAdminGetUserAuthTokensParams().WithUserID(userID)
+	return a.AdminGetUserAuthTokensWithParams(params, opts...)
+}
+
+func (a *Client) AdminGetUserAuthTokensWithParams(params *AdminGetUserAuthTokensParams, opts ...ClientOption) (*AdminGetUserAuthTokensOK, error) {
 	if params == nil {
 		params = NewAdminGetUserAuthTokensParams()
 	}
@@ -267,7 +303,12 @@ AdminLogoutUser logouts user revokes all auth tokens devices for the user user o
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.logout` and scope `global.users:*`.
 */
-func (a *Client) AdminLogoutUser(params *AdminLogoutUserParams, opts ...ClientOption) (*AdminLogoutUserOK, error) {
+func (a *Client) AdminLogoutUser(userID int64, opts ...ClientOption) (*AdminLogoutUserOK, error) {
+	params := NewAdminLogoutUserParams().WithUserID(userID)
+	return a.AdminLogoutUserWithParams(params, opts...)
+}
+
+func (a *Client) AdminLogoutUserWithParams(params *AdminLogoutUserParams, opts ...ClientOption) (*AdminLogoutUserOK, error) {
 	if params == nil {
 		params = NewAdminLogoutUserParams()
 	}
@@ -304,13 +345,17 @@ func (a *Client) AdminLogoutUser(params *AdminLogoutUserParams, opts ...ClientOp
 }
 
 /*
-	AdminRevokeUserAuthToken revokes auth token for user
+AdminRevokeUserAuthToken revokes auth token for user
 
-	Revokes the given auth token (device) for the user. User of issued auth token (device) will no longer be logged in and will be required to authenticate again upon next activity.
-
+Revokes the given auth token (device) for the user. User of issued auth token (device) will no longer be logged in and will be required to authenticate again upon next activity.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.authtoken:update` and scope `global.users:*`.
 */
-func (a *Client) AdminRevokeUserAuthToken(params *AdminRevokeUserAuthTokenParams, opts ...ClientOption) (*AdminRevokeUserAuthTokenOK, error) {
+func (a *Client) AdminRevokeUserAuthToken(userID int64, body *models.RevokeAuthTokenCmd, opts ...ClientOption) (*AdminRevokeUserAuthTokenOK, error) {
+	params := NewAdminRevokeUserAuthTokenParams().WithBody(body).WithUserID(userID)
+	return a.AdminRevokeUserAuthTokenWithParams(params, opts...)
+}
+
+func (a *Client) AdminRevokeUserAuthTokenWithParams(params *AdminRevokeUserAuthTokenParams, opts ...ClientOption) (*AdminRevokeUserAuthTokenOK, error) {
 	if params == nil {
 		params = NewAdminRevokeUserAuthTokenParams()
 	}
@@ -351,7 +396,12 @@ AdminUpdateUserPassword sets password for user
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.password:update` and scope `global.users:*`.
 */
-func (a *Client) AdminUpdateUserPassword(params *AdminUpdateUserPasswordParams, opts ...ClientOption) (*AdminUpdateUserPasswordOK, error) {
+func (a *Client) AdminUpdateUserPassword(userID int64, body *models.AdminUpdateUserPasswordForm, opts ...ClientOption) (*AdminUpdateUserPasswordOK, error) {
+	params := NewAdminUpdateUserPasswordParams().WithBody(body).WithUserID(userID)
+	return a.AdminUpdateUserPasswordWithParams(params, opts...)
+}
+
+func (a *Client) AdminUpdateUserPasswordWithParams(params *AdminUpdateUserPasswordParams, opts ...ClientOption) (*AdminUpdateUserPasswordOK, error) {
 	if params == nil {
 		params = NewAdminUpdateUserPasswordParams()
 	}
@@ -388,13 +438,17 @@ func (a *Client) AdminUpdateUserPassword(params *AdminUpdateUserPasswordParams, 
 }
 
 /*
-	AdminUpdateUserPermissions sets permissions for user
+AdminUpdateUserPermissions sets permissions for user
 
-	Only works with Basic Authentication (username and password). See introduction for an explanation.
-
+Only works with Basic Authentication (username and password). See introduction for an explanation.
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.permissions:update` and scope `global.users:*`.
 */
-func (a *Client) AdminUpdateUserPermissions(params *AdminUpdateUserPermissionsParams, opts ...ClientOption) (*AdminUpdateUserPermissionsOK, error) {
+func (a *Client) AdminUpdateUserPermissions(userID int64, body *models.AdminUpdateUserPermissionsForm, opts ...ClientOption) (*AdminUpdateUserPermissionsOK, error) {
+	params := NewAdminUpdateUserPermissionsParams().WithBody(body).WithUserID(userID)
+	return a.AdminUpdateUserPermissionsWithParams(params, opts...)
+}
+
+func (a *Client) AdminUpdateUserPermissionsWithParams(params *AdminUpdateUserPermissionsParams, opts ...ClientOption) (*AdminUpdateUserPermissionsOK, error) {
 	if params == nil {
 		params = NewAdminUpdateUserPermissionsParams()
 	}
@@ -435,7 +489,12 @@ GetUserQuota fetches user quota
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.quotas:list` and scope `global.users:1` (userIDScope).
 */
-func (a *Client) GetUserQuota(params *GetUserQuotaParams, opts ...ClientOption) (*GetUserQuotaOK, error) {
+func (a *Client) GetUserQuota(userID int64, opts ...ClientOption) (*GetUserQuotaOK, error) {
+	params := NewGetUserQuotaParams().WithUserID(userID)
+	return a.GetUserQuotaWithParams(params, opts...)
+}
+
+func (a *Client) GetUserQuotaWithParams(params *GetUserQuotaParams, opts ...ClientOption) (*GetUserQuotaOK, error) {
 	if params == nil {
 		params = NewGetUserQuotaParams()
 	}
@@ -476,6 +535,7 @@ UpdateUserQuota updates user quota
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `users.quotas:update` and scope `global.users:1` (userIDScope).
 */
+
 func (a *Client) UpdateUserQuota(params *UpdateUserQuotaParams, opts ...ClientOption) (*UpdateUserQuotaOK, error) {
 	if params == nil {
 		params = NewUpdateUserQuotaParams()

--- a/client/annotations/annotations_client.go
+++ b/client/annotations/annotations_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new annotations API client.
@@ -30,23 +32,30 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteAnnotationByID(params *DeleteAnnotationByIDParams, opts ...ClientOption) (*DeleteAnnotationByIDOK, error)
+	DeleteAnnotationByID(annotationID string, opts ...ClientOption) (*DeleteAnnotationByIDOK, error)
+	DeleteAnnotationByIDWithParams(params *DeleteAnnotationByIDParams, opts ...ClientOption) (*DeleteAnnotationByIDOK, error)
 
-	GetAnnotationByID(params *GetAnnotationByIDParams, opts ...ClientOption) (*GetAnnotationByIDOK, error)
+	GetAnnotationByID(annotationID string, opts ...ClientOption) (*GetAnnotationByIDOK, error)
+	GetAnnotationByIDWithParams(params *GetAnnotationByIDParams, opts ...ClientOption) (*GetAnnotationByIDOK, error)
 
 	GetAnnotationTags(params *GetAnnotationTagsParams, opts ...ClientOption) (*GetAnnotationTagsOK, error)
 
 	GetAnnotations(params *GetAnnotationsParams, opts ...ClientOption) (*GetAnnotationsOK, error)
 
-	MassDeleteAnnotations(params *MassDeleteAnnotationsParams, opts ...ClientOption) (*MassDeleteAnnotationsOK, error)
+	MassDeleteAnnotations(body *models.MassDeleteAnnotationsCmd, opts ...ClientOption) (*MassDeleteAnnotationsOK, error)
+	MassDeleteAnnotationsWithParams(params *MassDeleteAnnotationsParams, opts ...ClientOption) (*MassDeleteAnnotationsOK, error)
 
-	PatchAnnotation(params *PatchAnnotationParams, opts ...ClientOption) (*PatchAnnotationOK, error)
+	PatchAnnotation(annotationID string, body *models.PatchAnnotationsCmd, opts ...ClientOption) (*PatchAnnotationOK, error)
+	PatchAnnotationWithParams(params *PatchAnnotationParams, opts ...ClientOption) (*PatchAnnotationOK, error)
 
-	PostAnnotation(params *PostAnnotationParams, opts ...ClientOption) (*PostAnnotationOK, error)
+	PostAnnotation(body *models.PostAnnotationsCmd, opts ...ClientOption) (*PostAnnotationOK, error)
+	PostAnnotationWithParams(params *PostAnnotationParams, opts ...ClientOption) (*PostAnnotationOK, error)
 
-	PostGraphiteAnnotation(params *PostGraphiteAnnotationParams, opts ...ClientOption) (*PostGraphiteAnnotationOK, error)
+	PostGraphiteAnnotation(body *models.PostGraphiteAnnotationsCmd, opts ...ClientOption) (*PostGraphiteAnnotationOK, error)
+	PostGraphiteAnnotationWithParams(params *PostGraphiteAnnotationParams, opts ...ClientOption) (*PostGraphiteAnnotationOK, error)
 
-	UpdateAnnotation(params *UpdateAnnotationParams, opts ...ClientOption) (*UpdateAnnotationOK, error)
+	UpdateAnnotation(annotationID string, body *models.UpdateAnnotationsCmd, opts ...ClientOption) (*UpdateAnnotationOK, error)
+	UpdateAnnotationWithParams(params *UpdateAnnotationParams, opts ...ClientOption) (*UpdateAnnotationOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -56,7 +65,12 @@ DeleteAnnotationByID deletes annotation by ID
 
 Deletes the annotation that matches the specified ID.
 */
-func (a *Client) DeleteAnnotationByID(params *DeleteAnnotationByIDParams, opts ...ClientOption) (*DeleteAnnotationByIDOK, error) {
+func (a *Client) DeleteAnnotationByID(annotationID string, opts ...ClientOption) (*DeleteAnnotationByIDOK, error) {
+	params := NewDeleteAnnotationByIDParams().WithAnnotationID(annotationID)
+	return a.DeleteAnnotationByIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteAnnotationByIDWithParams(params *DeleteAnnotationByIDParams, opts ...ClientOption) (*DeleteAnnotationByIDOK, error) {
 	if params == nil {
 		params = NewDeleteAnnotationByIDParams()
 	}
@@ -95,7 +109,12 @@ func (a *Client) DeleteAnnotationByID(params *DeleteAnnotationByIDParams, opts .
 /*
 GetAnnotationByID gets annotation by ID
 */
-func (a *Client) GetAnnotationByID(params *GetAnnotationByIDParams, opts ...ClientOption) (*GetAnnotationByIDOK, error) {
+func (a *Client) GetAnnotationByID(annotationID string, opts ...ClientOption) (*GetAnnotationByIDOK, error) {
+	params := NewGetAnnotationByIDParams().WithAnnotationID(annotationID)
+	return a.GetAnnotationByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetAnnotationByIDWithParams(params *GetAnnotationByIDParams, opts ...ClientOption) (*GetAnnotationByIDOK, error) {
 	if params == nil {
 		params = NewGetAnnotationByIDParams()
 	}
@@ -136,6 +155,7 @@ GetAnnotationTags finds annotations tags
 
 Find all the event tags created in the annotations.
 */
+
 func (a *Client) GetAnnotationTags(params *GetAnnotationTagsParams, opts ...ClientOption) (*GetAnnotationTagsOK, error) {
 	if params == nil {
 		params = NewGetAnnotationTagsParams()
@@ -177,6 +197,7 @@ GetAnnotations finds annotations
 
 Starting in Grafana v6.4 regions annotations are now returned in one entity that now includes the timeEnd property.
 */
+
 func (a *Client) GetAnnotations(params *GetAnnotationsParams, opts ...ClientOption) (*GetAnnotationsOK, error) {
 	if params == nil {
 		params = NewGetAnnotationsParams()
@@ -216,7 +237,12 @@ func (a *Client) GetAnnotations(params *GetAnnotationsParams, opts ...ClientOpti
 /*
 MassDeleteAnnotations deletes multiple annotations
 */
-func (a *Client) MassDeleteAnnotations(params *MassDeleteAnnotationsParams, opts ...ClientOption) (*MassDeleteAnnotationsOK, error) {
+func (a *Client) MassDeleteAnnotations(body *models.MassDeleteAnnotationsCmd, opts ...ClientOption) (*MassDeleteAnnotationsOK, error) {
+	params := NewMassDeleteAnnotationsParams().WithBody(body)
+	return a.MassDeleteAnnotationsWithParams(params, opts...)
+}
+
+func (a *Client) MassDeleteAnnotationsWithParams(params *MassDeleteAnnotationsParams, opts ...ClientOption) (*MassDeleteAnnotationsOK, error) {
 	if params == nil {
 		params = NewMassDeleteAnnotationsParams()
 	}
@@ -253,14 +279,18 @@ func (a *Client) MassDeleteAnnotations(params *MassDeleteAnnotationsParams, opts
 }
 
 /*
-	PatchAnnotation patches annotation
+PatchAnnotation patches annotation
 
-	Updates one or more properties of an annotation that matches the specified ID.
-
+Updates one or more properties of an annotation that matches the specified ID.
 This operation currently supports updating of the `text`, `tags`, `time` and `timeEnd` properties.
 This is available in Grafana 6.0.0-beta2 and above.
 */
-func (a *Client) PatchAnnotation(params *PatchAnnotationParams, opts ...ClientOption) (*PatchAnnotationOK, error) {
+func (a *Client) PatchAnnotation(annotationID string, body *models.PatchAnnotationsCmd, opts ...ClientOption) (*PatchAnnotationOK, error) {
+	params := NewPatchAnnotationParams().WithAnnotationID(annotationID).WithBody(body)
+	return a.PatchAnnotationWithParams(params, opts...)
+}
+
+func (a *Client) PatchAnnotationWithParams(params *PatchAnnotationParams, opts ...ClientOption) (*PatchAnnotationOK, error) {
 	if params == nil {
 		params = NewPatchAnnotationParams()
 	}
@@ -297,14 +327,18 @@ func (a *Client) PatchAnnotation(params *PatchAnnotationParams, opts ...ClientOp
 }
 
 /*
-	PostAnnotation creates annotation
+PostAnnotation creates annotation
 
-	Creates an annotation in the Grafana database. The dashboardId and panelId fields are optional. If they are not specified then an organization annotation is created and can be queried in any dashboard that adds the Grafana annotations data source. When creating a region annotation include the timeEnd property.
-
+Creates an annotation in the Grafana database. The dashboardId and panelId fields are optional. If they are not specified then an organization annotation is created and can be queried in any dashboard that adds the Grafana annotations data source. When creating a region annotation include the timeEnd property.
 The format for `time` and `timeEnd` should be epoch numbers in millisecond resolution.
 The response for this HTTP request is slightly different in versions prior to v6.4. In prior versions you would also get an endId if you where creating a region. But in 6.4 regions are represented using a single event with time and timeEnd properties.
 */
-func (a *Client) PostAnnotation(params *PostAnnotationParams, opts ...ClientOption) (*PostAnnotationOK, error) {
+func (a *Client) PostAnnotation(body *models.PostAnnotationsCmd, opts ...ClientOption) (*PostAnnotationOK, error) {
+	params := NewPostAnnotationParams().WithBody(body)
+	return a.PostAnnotationWithParams(params, opts...)
+}
+
+func (a *Client) PostAnnotationWithParams(params *PostAnnotationParams, opts ...ClientOption) (*PostAnnotationOK, error) {
 	if params == nil {
 		params = NewPostAnnotationParams()
 	}
@@ -345,7 +379,12 @@ PostGraphiteAnnotation creates annotation in graphite format
 
 Creates an annotation by using Graphite-compatible event format. The `when` and `data` fields are optional. If `when` is not specified then the current time will be used as annotation’s timestamp. The `tags` field can also be in prior to Graphite `0.10.0` format (string with multiple tags being separated by a space).
 */
-func (a *Client) PostGraphiteAnnotation(params *PostGraphiteAnnotationParams, opts ...ClientOption) (*PostGraphiteAnnotationOK, error) {
+func (a *Client) PostGraphiteAnnotation(body *models.PostGraphiteAnnotationsCmd, opts ...ClientOption) (*PostGraphiteAnnotationOK, error) {
+	params := NewPostGraphiteAnnotationParams().WithBody(body)
+	return a.PostGraphiteAnnotationWithParams(params, opts...)
+}
+
+func (a *Client) PostGraphiteAnnotationWithParams(params *PostGraphiteAnnotationParams, opts ...ClientOption) (*PostGraphiteAnnotationOK, error) {
 	if params == nil {
 		params = NewPostGraphiteAnnotationParams()
 	}
@@ -386,7 +425,12 @@ UpdateAnnotation updates annotation
 
 Updates all properties of an annotation that matches the specified id. To only update certain property, consider using the Patch Annotation operation.
 */
-func (a *Client) UpdateAnnotation(params *UpdateAnnotationParams, opts ...ClientOption) (*UpdateAnnotationOK, error) {
+func (a *Client) UpdateAnnotation(annotationID string, body *models.UpdateAnnotationsCmd, opts ...ClientOption) (*UpdateAnnotationOK, error) {
+	params := NewUpdateAnnotationParams().WithAnnotationID(annotationID).WithBody(body)
+	return a.UpdateAnnotationWithParams(params, opts...)
+}
+
+func (a *Client) UpdateAnnotationWithParams(params *UpdateAnnotationParams, opts ...ClientOption) (*UpdateAnnotationOK, error) {
 	if params == nil {
 		params = NewUpdateAnnotationParams()
 	}

--- a/client/api_keys/api_keys_client.go
+++ b/client/api_keys/api_keys_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new api keys API client.
@@ -30,9 +32,11 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddAPIkey(params *AddAPIkeyParams, opts ...ClientOption) (*AddAPIkeyOK, error)
+	AddAPIkey(body *models.AddCommand, opts ...ClientOption) (*AddAPIkeyOK, error)
+	AddAPIkeyWithParams(params *AddAPIkeyParams, opts ...ClientOption) (*AddAPIkeyOK, error)
 
-	DeleteAPIkey(params *DeleteAPIkeyParams, opts ...ClientOption) (*DeleteAPIkeyOK, error)
+	DeleteAPIkey(id int64, opts ...ClientOption) (*DeleteAPIkeyOK, error)
+	DeleteAPIkeyWithParams(params *DeleteAPIkeyParams, opts ...ClientOption) (*DeleteAPIkeyOK, error)
 
 	GetAPIkeys(params *GetAPIkeysParams, opts ...ClientOption) (*GetAPIkeysOK, error)
 
@@ -44,7 +48,12 @@ AddAPIkey creates an API key
 
 Will return details of the created API key.
 */
-func (a *Client) AddAPIkey(params *AddAPIkeyParams, opts ...ClientOption) (*AddAPIkeyOK, error) {
+func (a *Client) AddAPIkey(body *models.AddCommand, opts ...ClientOption) (*AddAPIkeyOK, error) {
+	params := NewAddAPIkeyParams().WithBody(body)
+	return a.AddAPIkeyWithParams(params, opts...)
+}
+
+func (a *Client) AddAPIkeyWithParams(params *AddAPIkeyParams, opts ...ClientOption) (*AddAPIkeyOK, error) {
 	if params == nil {
 		params = NewAddAPIkeyParams()
 	}
@@ -81,13 +90,17 @@ func (a *Client) AddAPIkey(params *AddAPIkeyParams, opts ...ClientOption) (*AddA
 }
 
 /*
-	DeleteAPIkey deletes API key
+DeleteAPIkey deletes API key
 
-	Deletes an API key.
-
+Deletes an API key.
 Deprecated. See: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 */
-func (a *Client) DeleteAPIkey(params *DeleteAPIkeyParams, opts ...ClientOption) (*DeleteAPIkeyOK, error) {
+func (a *Client) DeleteAPIkey(id int64, opts ...ClientOption) (*DeleteAPIkeyOK, error) {
+	params := NewDeleteAPIkeyParams().WithID(id)
+	return a.DeleteAPIkeyWithParams(params, opts...)
+}
+
+func (a *Client) DeleteAPIkeyWithParams(params *DeleteAPIkeyParams, opts ...ClientOption) (*DeleteAPIkeyOK, error) {
 	if params == nil {
 		params = NewDeleteAPIkeyParams()
 	}
@@ -124,15 +137,16 @@ func (a *Client) DeleteAPIkey(params *DeleteAPIkeyParams, opts ...ClientOption) 
 }
 
 /*
-	GetAPIkeys gets auth keys
+GetAPIkeys gets auth keys
 
-	Will return auth keys.
+Will return auth keys.
 
 Deprecated: true.
 
 Deprecated. Please use GET /api/serviceaccounts and GET /api/serviceaccounts/{id}/tokens instead
 see https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 */
+
 func (a *Client) GetAPIkeys(params *GetAPIkeysParams, opts ...ClientOption) (*GetAPIkeysOK, error) {
 	if params == nil {
 		params = NewGetAPIkeysParams()

--- a/client/correlations/correlations_client.go
+++ b/client/correlations/correlations_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new correlations API client.
@@ -30,15 +32,19 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateCorrelation(params *CreateCorrelationParams, opts ...ClientOption) (*CreateCorrelationOK, error)
+	CreateCorrelation(sourceUID string, body *models.CreateCorrelationCommand, opts ...ClientOption) (*CreateCorrelationOK, error)
+	CreateCorrelationWithParams(params *CreateCorrelationParams, opts ...ClientOption) (*CreateCorrelationOK, error)
 
-	DeleteCorrelation(params *DeleteCorrelationParams, opts ...ClientOption) (*DeleteCorrelationOK, error)
+	DeleteCorrelation(uid string, correlationUID string, opts ...ClientOption) (*DeleteCorrelationOK, error)
+	DeleteCorrelationWithParams(params *DeleteCorrelationParams, opts ...ClientOption) (*DeleteCorrelationOK, error)
 
-	GetCorrelation(params *GetCorrelationParams, opts ...ClientOption) (*GetCorrelationOK, error)
+	GetCorrelation(sourceUID string, correlationUID string, opts ...ClientOption) (*GetCorrelationOK, error)
+	GetCorrelationWithParams(params *GetCorrelationParams, opts ...ClientOption) (*GetCorrelationOK, error)
 
 	GetCorrelations(params *GetCorrelationsParams, opts ...ClientOption) (*GetCorrelationsOK, error)
 
-	GetCorrelationsBySourceUID(params *GetCorrelationsBySourceUIDParams, opts ...ClientOption) (*GetCorrelationsBySourceUIDOK, error)
+	GetCorrelationsBySourceUID(sourceUID string, opts ...ClientOption) (*GetCorrelationsBySourceUIDOK, error)
+	GetCorrelationsBySourceUIDWithParams(params *GetCorrelationsBySourceUIDParams, opts ...ClientOption) (*GetCorrelationsBySourceUIDOK, error)
 
 	UpdateCorrelation(params *UpdateCorrelationParams, opts ...ClientOption) (*UpdateCorrelationOK, error)
 
@@ -48,7 +54,12 @@ type ClientService interface {
 /*
 CreateCorrelation adds correlation
 */
-func (a *Client) CreateCorrelation(params *CreateCorrelationParams, opts ...ClientOption) (*CreateCorrelationOK, error) {
+func (a *Client) CreateCorrelation(sourceUID string, body *models.CreateCorrelationCommand, opts ...ClientOption) (*CreateCorrelationOK, error) {
+	params := NewCreateCorrelationParams().WithBody(body).WithSourceUID(sourceUID)
+	return a.CreateCorrelationWithParams(params, opts...)
+}
+
+func (a *Client) CreateCorrelationWithParams(params *CreateCorrelationParams, opts ...ClientOption) (*CreateCorrelationOK, error) {
 	if params == nil {
 		params = NewCreateCorrelationParams()
 	}
@@ -87,7 +98,12 @@ func (a *Client) CreateCorrelation(params *CreateCorrelationParams, opts ...Clie
 /*
 DeleteCorrelation deletes a correlation
 */
-func (a *Client) DeleteCorrelation(params *DeleteCorrelationParams, opts ...ClientOption) (*DeleteCorrelationOK, error) {
+func (a *Client) DeleteCorrelation(uid string, correlationUID string, opts ...ClientOption) (*DeleteCorrelationOK, error) {
+	params := NewDeleteCorrelationParams().WithCorrelationUID(correlationUID).WithUID(uid)
+	return a.DeleteCorrelationWithParams(params, opts...)
+}
+
+func (a *Client) DeleteCorrelationWithParams(params *DeleteCorrelationParams, opts ...ClientOption) (*DeleteCorrelationOK, error) {
 	if params == nil {
 		params = NewDeleteCorrelationParams()
 	}
@@ -126,7 +142,12 @@ func (a *Client) DeleteCorrelation(params *DeleteCorrelationParams, opts ...Clie
 /*
 GetCorrelation gets a correlation
 */
-func (a *Client) GetCorrelation(params *GetCorrelationParams, opts ...ClientOption) (*GetCorrelationOK, error) {
+func (a *Client) GetCorrelation(sourceUID string, correlationUID string, opts ...ClientOption) (*GetCorrelationOK, error) {
+	params := NewGetCorrelationParams().WithCorrelationUID(correlationUID).WithSourceUID(sourceUID)
+	return a.GetCorrelationWithParams(params, opts...)
+}
+
+func (a *Client) GetCorrelationWithParams(params *GetCorrelationParams, opts ...ClientOption) (*GetCorrelationOK, error) {
 	if params == nil {
 		params = NewGetCorrelationParams()
 	}
@@ -165,6 +186,7 @@ func (a *Client) GetCorrelation(params *GetCorrelationParams, opts ...ClientOpti
 /*
 GetCorrelations gets all correlations
 */
+
 func (a *Client) GetCorrelations(params *GetCorrelationsParams, opts ...ClientOption) (*GetCorrelationsOK, error) {
 	if params == nil {
 		params = NewGetCorrelationsParams()
@@ -204,7 +226,12 @@ func (a *Client) GetCorrelations(params *GetCorrelationsParams, opts ...ClientOp
 /*
 GetCorrelationsBySourceUID gets all correlations originating from the given data source
 */
-func (a *Client) GetCorrelationsBySourceUID(params *GetCorrelationsBySourceUIDParams, opts ...ClientOption) (*GetCorrelationsBySourceUIDOK, error) {
+func (a *Client) GetCorrelationsBySourceUID(sourceUID string, opts ...ClientOption) (*GetCorrelationsBySourceUIDOK, error) {
+	params := NewGetCorrelationsBySourceUIDParams().WithSourceUID(sourceUID)
+	return a.GetCorrelationsBySourceUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetCorrelationsBySourceUIDWithParams(params *GetCorrelationsBySourceUIDParams, opts ...ClientOption) (*GetCorrelationsBySourceUIDOK, error) {
 	if params == nil {
 		params = NewGetCorrelationsBySourceUIDParams()
 	}
@@ -243,6 +270,7 @@ func (a *Client) GetCorrelationsBySourceUID(params *GetCorrelationsBySourceUIDPa
 /*
 UpdateCorrelation updates a correlation
 */
+
 func (a *Client) UpdateCorrelation(params *UpdateCorrelationParams, opts ...ClientOption) (*UpdateCorrelationOK, error) {
 	if params == nil {
 		params = NewUpdateCorrelationParams()

--- a/client/dashboard_permissions/dashboard_permissions_client.go
+++ b/client/dashboard_permissions/dashboard_permissions_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new dashboard permissions API client.
@@ -30,13 +32,17 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetDashboardPermissionsListByID(params *GetDashboardPermissionsListByIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByIDOK, error)
+	GetDashboardPermissionsListByID(dashboardID int64, opts ...ClientOption) (*GetDashboardPermissionsListByIDOK, error)
+	GetDashboardPermissionsListByIDWithParams(params *GetDashboardPermissionsListByIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByIDOK, error)
 
-	GetDashboardPermissionsListByUID(params *GetDashboardPermissionsListByUIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByUIDOK, error)
+	GetDashboardPermissionsListByUID(uid string, opts ...ClientOption) (*GetDashboardPermissionsListByUIDOK, error)
+	GetDashboardPermissionsListByUIDWithParams(params *GetDashboardPermissionsListByUIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByUIDOK, error)
 
-	UpdateDashboardPermissionsByID(params *UpdateDashboardPermissionsByIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByIDOK, error)
+	UpdateDashboardPermissionsByID(dashboardID int64, body *models.UpdateDashboardACLCommand, opts ...ClientOption) (*UpdateDashboardPermissionsByIDOK, error)
+	UpdateDashboardPermissionsByIDWithParams(params *UpdateDashboardPermissionsByIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByIDOK, error)
 
-	UpdateDashboardPermissionsByUID(params *UpdateDashboardPermissionsByUIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByUIDOK, error)
+	UpdateDashboardPermissionsByUID(uid string, body *models.UpdateDashboardACLCommand, opts ...ClientOption) (*UpdateDashboardPermissionsByUIDOK, error)
+	UpdateDashboardPermissionsByUIDWithParams(params *UpdateDashboardPermissionsByUIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByUIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -46,7 +52,12 @@ GetDashboardPermissionsListByID gets all existing permissions for the given dash
 
 Please refer to [updated API](#/dashboard_permissions/getDashboardPermissionsListByUID) instead
 */
-func (a *Client) GetDashboardPermissionsListByID(params *GetDashboardPermissionsListByIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByIDOK, error) {
+func (a *Client) GetDashboardPermissionsListByID(dashboardID int64, opts ...ClientOption) (*GetDashboardPermissionsListByIDOK, error) {
+	params := NewGetDashboardPermissionsListByIDParams().WithDashboardID(dashboardID)
+	return a.GetDashboardPermissionsListByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardPermissionsListByIDWithParams(params *GetDashboardPermissionsListByIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardPermissionsListByIDParams()
 	}
@@ -85,7 +96,12 @@ func (a *Client) GetDashboardPermissionsListByID(params *GetDashboardPermissions
 /*
 GetDashboardPermissionsListByUID gets all existing permissions for the given dashboard
 */
-func (a *Client) GetDashboardPermissionsListByUID(params *GetDashboardPermissionsListByUIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByUIDOK, error) {
+func (a *Client) GetDashboardPermissionsListByUID(uid string, opts ...ClientOption) (*GetDashboardPermissionsListByUIDOK, error) {
+	params := NewGetDashboardPermissionsListByUIDParams().WithUID(uid)
+	return a.GetDashboardPermissionsListByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardPermissionsListByUIDWithParams(params *GetDashboardPermissionsListByUIDParams, opts ...ClientOption) (*GetDashboardPermissionsListByUIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardPermissionsListByUIDParams()
 	}
@@ -122,13 +138,18 @@ func (a *Client) GetDashboardPermissionsListByUID(params *GetDashboardPermission
 }
 
 /*
-	UpdateDashboardPermissionsByID updates permissions for a dashboard
+UpdateDashboardPermissionsByID updates permissions for a dashboard
 
-	Please refer to [updated API](#/dashboard_permissions/updateDashboardPermissionsByUID) instead
+Please refer to [updated API](#/dashboard_permissions/updateDashboardPermissionsByUID) instead
 
 This operation will remove existing permissions if they’re not included in the request.
 */
-func (a *Client) UpdateDashboardPermissionsByID(params *UpdateDashboardPermissionsByIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByIDOK, error) {
+func (a *Client) UpdateDashboardPermissionsByID(dashboardID int64, body *models.UpdateDashboardACLCommand, opts ...ClientOption) (*UpdateDashboardPermissionsByIDOK, error) {
+	params := NewUpdateDashboardPermissionsByIDParams().WithBody(body).WithDashboardID(dashboardID)
+	return a.UpdateDashboardPermissionsByIDWithParams(params, opts...)
+}
+
+func (a *Client) UpdateDashboardPermissionsByIDWithParams(params *UpdateDashboardPermissionsByIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByIDOK, error) {
 	if params == nil {
 		params = NewUpdateDashboardPermissionsByIDParams()
 	}
@@ -169,7 +190,12 @@ UpdateDashboardPermissionsByUID updates permissions for a dashboard
 
 This operation will remove existing permissions if they’re not included in the request.
 */
-func (a *Client) UpdateDashboardPermissionsByUID(params *UpdateDashboardPermissionsByUIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByUIDOK, error) {
+func (a *Client) UpdateDashboardPermissionsByUID(uid string, body *models.UpdateDashboardACLCommand, opts ...ClientOption) (*UpdateDashboardPermissionsByUIDOK, error) {
+	params := NewUpdateDashboardPermissionsByUIDParams().WithBody(body).WithUID(uid)
+	return a.UpdateDashboardPermissionsByUIDWithParams(params, opts...)
+}
+
+func (a *Client) UpdateDashboardPermissionsByUIDWithParams(params *UpdateDashboardPermissionsByUIDParams, opts ...ClientOption) (*UpdateDashboardPermissionsByUIDOK, error) {
 	if params == nil {
 		params = NewUpdateDashboardPermissionsByUIDParams()
 	}

--- a/client/dashboard_versions/dashboard_versions_client.go
+++ b/client/dashboard_versions/dashboard_versions_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new dashboard versions API client.
@@ -30,17 +32,22 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetDashboardVersionByID(params *GetDashboardVersionByIDParams, opts ...ClientOption) (*GetDashboardVersionByIDOK, error)
+	GetDashboardVersionByID(dashboardVersionID int64, dashboardID int64, opts ...ClientOption) (*GetDashboardVersionByIDOK, error)
+	GetDashboardVersionByIDWithParams(params *GetDashboardVersionByIDParams, opts ...ClientOption) (*GetDashboardVersionByIDOK, error)
 
-	GetDashboardVersionByUID(params *GetDashboardVersionByUIDParams, opts ...ClientOption) (*GetDashboardVersionByUIDOK, error)
+	GetDashboardVersionByUID(uid string, dashboardVersionID int64, opts ...ClientOption) (*GetDashboardVersionByUIDOK, error)
+	GetDashboardVersionByUIDWithParams(params *GetDashboardVersionByUIDParams, opts ...ClientOption) (*GetDashboardVersionByUIDOK, error)
 
-	GetDashboardVersionsByID(params *GetDashboardVersionsByIDParams, opts ...ClientOption) (*GetDashboardVersionsByIDOK, error)
+	GetDashboardVersionsByID(dashboardID int64, opts ...ClientOption) (*GetDashboardVersionsByIDOK, error)
+	GetDashboardVersionsByIDWithParams(params *GetDashboardVersionsByIDParams, opts ...ClientOption) (*GetDashboardVersionsByIDOK, error)
 
 	GetDashboardVersionsByUID(params *GetDashboardVersionsByUIDParams, opts ...ClientOption) (*GetDashboardVersionsByUIDOK, error)
 
-	RestoreDashboardVersionByID(params *RestoreDashboardVersionByIDParams, opts ...ClientOption) (*RestoreDashboardVersionByIDOK, error)
+	RestoreDashboardVersionByID(dashboardID int64, body *models.RestoreDashboardVersionCommand, opts ...ClientOption) (*RestoreDashboardVersionByIDOK, error)
+	RestoreDashboardVersionByIDWithParams(params *RestoreDashboardVersionByIDParams, opts ...ClientOption) (*RestoreDashboardVersionByIDOK, error)
 
-	RestoreDashboardVersionByUID(params *RestoreDashboardVersionByUIDParams, opts ...ClientOption) (*RestoreDashboardVersionByUIDOK, error)
+	RestoreDashboardVersionByUID(uid string, body *models.RestoreDashboardVersionCommand, opts ...ClientOption) (*RestoreDashboardVersionByUIDOK, error)
+	RestoreDashboardVersionByUIDWithParams(params *RestoreDashboardVersionByUIDParams, opts ...ClientOption) (*RestoreDashboardVersionByUIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -50,7 +57,12 @@ GetDashboardVersionByID gets a specific dashboard version
 
 Please refer to [updated API](#/dashboard_versions/getDashboardVersionByUID) instead
 */
-func (a *Client) GetDashboardVersionByID(params *GetDashboardVersionByIDParams, opts ...ClientOption) (*GetDashboardVersionByIDOK, error) {
+func (a *Client) GetDashboardVersionByID(dashboardVersionID int64, dashboardID int64, opts ...ClientOption) (*GetDashboardVersionByIDOK, error) {
+	params := NewGetDashboardVersionByIDParams().WithDashboardID(dashboardID).WithDashboardVersionID(dashboardVersionID)
+	return a.GetDashboardVersionByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardVersionByIDWithParams(params *GetDashboardVersionByIDParams, opts ...ClientOption) (*GetDashboardVersionByIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardVersionByIDParams()
 	}
@@ -89,7 +101,12 @@ func (a *Client) GetDashboardVersionByID(params *GetDashboardVersionByIDParams, 
 /*
 GetDashboardVersionByUID gets a specific dashboard version using UID
 */
-func (a *Client) GetDashboardVersionByUID(params *GetDashboardVersionByUIDParams, opts ...ClientOption) (*GetDashboardVersionByUIDOK, error) {
+func (a *Client) GetDashboardVersionByUID(uid string, dashboardVersionID int64, opts ...ClientOption) (*GetDashboardVersionByUIDOK, error) {
+	params := NewGetDashboardVersionByUIDParams().WithDashboardVersionID(dashboardVersionID).WithUID(uid)
+	return a.GetDashboardVersionByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardVersionByUIDWithParams(params *GetDashboardVersionByUIDParams, opts ...ClientOption) (*GetDashboardVersionByUIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardVersionByUIDParams()
 	}
@@ -130,7 +147,12 @@ GetDashboardVersionsByID gets all existing versions for the dashboard
 
 Please refer to [updated API](#/dashboard_versions/getDashboardVersionsByUID) instead
 */
-func (a *Client) GetDashboardVersionsByID(params *GetDashboardVersionsByIDParams, opts ...ClientOption) (*GetDashboardVersionsByIDOK, error) {
+func (a *Client) GetDashboardVersionsByID(dashboardID int64, opts ...ClientOption) (*GetDashboardVersionsByIDOK, error) {
+	params := NewGetDashboardVersionsByIDParams().WithDashboardID(dashboardID)
+	return a.GetDashboardVersionsByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardVersionsByIDWithParams(params *GetDashboardVersionsByIDParams, opts ...ClientOption) (*GetDashboardVersionsByIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardVersionsByIDParams()
 	}
@@ -169,6 +191,7 @@ func (a *Client) GetDashboardVersionsByID(params *GetDashboardVersionsByIDParams
 /*
 GetDashboardVersionsByUID gets all existing versions for the dashboard using UID
 */
+
 func (a *Client) GetDashboardVersionsByUID(params *GetDashboardVersionsByUIDParams, opts ...ClientOption) (*GetDashboardVersionsByUIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardVersionsByUIDParams()
@@ -210,7 +233,12 @@ RestoreDashboardVersionByID restores a dashboard to a given dashboard version
 
 Please refer to [updated API](#/dashboard_versions/restoreDashboardVersionByUID) instead
 */
-func (a *Client) RestoreDashboardVersionByID(params *RestoreDashboardVersionByIDParams, opts ...ClientOption) (*RestoreDashboardVersionByIDOK, error) {
+func (a *Client) RestoreDashboardVersionByID(dashboardID int64, body *models.RestoreDashboardVersionCommand, opts ...ClientOption) (*RestoreDashboardVersionByIDOK, error) {
+	params := NewRestoreDashboardVersionByIDParams().WithBody(body).WithDashboardID(dashboardID)
+	return a.RestoreDashboardVersionByIDWithParams(params, opts...)
+}
+
+func (a *Client) RestoreDashboardVersionByIDWithParams(params *RestoreDashboardVersionByIDParams, opts ...ClientOption) (*RestoreDashboardVersionByIDOK, error) {
 	if params == nil {
 		params = NewRestoreDashboardVersionByIDParams()
 	}
@@ -249,7 +277,12 @@ func (a *Client) RestoreDashboardVersionByID(params *RestoreDashboardVersionByID
 /*
 RestoreDashboardVersionByUID restores a dashboard to a given dashboard version using UID
 */
-func (a *Client) RestoreDashboardVersionByUID(params *RestoreDashboardVersionByUIDParams, opts ...ClientOption) (*RestoreDashboardVersionByUIDOK, error) {
+func (a *Client) RestoreDashboardVersionByUID(uid string, body *models.RestoreDashboardVersionCommand, opts ...ClientOption) (*RestoreDashboardVersionByUIDOK, error) {
+	params := NewRestoreDashboardVersionByUIDParams().WithBody(body).WithUID(uid)
+	return a.RestoreDashboardVersionByUIDWithParams(params, opts...)
+}
+
+func (a *Client) RestoreDashboardVersionByUIDWithParams(params *RestoreDashboardVersionByUIDParams, opts ...ClientOption) (*RestoreDashboardVersionByUIDOK, error) {
 	if params == nil {
 		params = NewRestoreDashboardVersionByUIDParams()
 	}

--- a/client/dashboards/dashboards_client.go
+++ b/client/dashboards/dashboards_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new dashboards API client.
@@ -30,11 +32,14 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CalculateDashboardDiff(params *CalculateDashboardDiffParams, opts ...ClientOption) (*CalculateDashboardDiffOK, error)
+	CalculateDashboardDiff(body *models.CalculateDashboardDiffParamsBody, opts ...ClientOption) (*CalculateDashboardDiffOK, error)
+	CalculateDashboardDiffWithParams(params *CalculateDashboardDiffParams, opts ...ClientOption) (*CalculateDashboardDiffOK, error)
 
-	DeleteDashboardByUID(params *DeleteDashboardByUIDParams, opts ...ClientOption) (*DeleteDashboardByUIDOK, error)
+	DeleteDashboardByUID(uid string, opts ...ClientOption) (*DeleteDashboardByUIDOK, error)
+	DeleteDashboardByUIDWithParams(params *DeleteDashboardByUIDParams, opts ...ClientOption) (*DeleteDashboardByUIDOK, error)
 
-	GetDashboardByUID(params *GetDashboardByUIDParams, opts ...ClientOption) (*GetDashboardByUIDOK, error)
+	GetDashboardByUID(uid string, opts ...ClientOption) (*GetDashboardByUIDOK, error)
+	GetDashboardByUIDWithParams(params *GetDashboardByUIDParams, opts ...ClientOption) (*GetDashboardByUIDOK, error)
 
 	GetDashboardTags(opts ...ClientOption) (*GetDashboardTagsOK, error)
 	GetDashboardTagsWithParams(params *GetDashboardTagsParams, opts ...ClientOption) (*GetDashboardTagsOK, error)
@@ -42,11 +47,14 @@ type ClientService interface {
 	GetHomeDashboard(opts ...ClientOption) (*GetHomeDashboardOK, error)
 	GetHomeDashboardWithParams(params *GetHomeDashboardParams, opts ...ClientOption) (*GetHomeDashboardOK, error)
 
-	ImportDashboard(params *ImportDashboardParams, opts ...ClientOption) (*ImportDashboardOK, error)
+	ImportDashboard(body *models.ImportDashboardRequest, opts ...ClientOption) (*ImportDashboardOK, error)
+	ImportDashboardWithParams(params *ImportDashboardParams, opts ...ClientOption) (*ImportDashboardOK, error)
 
-	PostDashboard(params *PostDashboardParams, opts ...ClientOption) (*PostDashboardOK, error)
+	PostDashboard(body *models.SaveDashboardCommand, opts ...ClientOption) (*PostDashboardOK, error)
+	PostDashboardWithParams(params *PostDashboardParams, opts ...ClientOption) (*PostDashboardOK, error)
 
-	TrimDashboard(params *TrimDashboardParams, opts ...ClientOption) (*TrimDashboardOK, error)
+	TrimDashboard(body *models.TrimDashboardCommand, opts ...ClientOption) (*TrimDashboardOK, error)
+	TrimDashboardWithParams(params *TrimDashboardParams, opts ...ClientOption) (*TrimDashboardOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -54,7 +62,12 @@ type ClientService interface {
 /*
 CalculateDashboardDiff performs diff on two dashboards
 */
-func (a *Client) CalculateDashboardDiff(params *CalculateDashboardDiffParams, opts ...ClientOption) (*CalculateDashboardDiffOK, error) {
+func (a *Client) CalculateDashboardDiff(body *models.CalculateDashboardDiffParamsBody, opts ...ClientOption) (*CalculateDashboardDiffOK, error) {
+	params := NewCalculateDashboardDiffParams().WithBody(body)
+	return a.CalculateDashboardDiffWithParams(params, opts...)
+}
+
+func (a *Client) CalculateDashboardDiffWithParams(params *CalculateDashboardDiffParams, opts ...ClientOption) (*CalculateDashboardDiffOK, error) {
 	if params == nil {
 		params = NewCalculateDashboardDiffParams()
 	}
@@ -95,7 +108,12 @@ DeleteDashboardByUID deletes dashboard by uid
 
 Will delete the dashboard given the specified unique identifier (uid).
 */
-func (a *Client) DeleteDashboardByUID(params *DeleteDashboardByUIDParams, opts ...ClientOption) (*DeleteDashboardByUIDOK, error) {
+func (a *Client) DeleteDashboardByUID(uid string, opts ...ClientOption) (*DeleteDashboardByUIDOK, error) {
+	params := NewDeleteDashboardByUIDParams().WithUID(uid)
+	return a.DeleteDashboardByUIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteDashboardByUIDWithParams(params *DeleteDashboardByUIDParams, opts ...ClientOption) (*DeleteDashboardByUIDOK, error) {
 	if params == nil {
 		params = NewDeleteDashboardByUIDParams()
 	}
@@ -136,7 +154,12 @@ GetDashboardByUID gets dashboard by uid
 
 Will return the dashboard given the dashboard unique identifier (uid).
 */
-func (a *Client) GetDashboardByUID(params *GetDashboardByUIDParams, opts ...ClientOption) (*GetDashboardByUIDOK, error) {
+func (a *Client) GetDashboardByUID(uid string, opts ...ClientOption) (*GetDashboardByUIDOK, error) {
+	params := NewGetDashboardByUIDParams().WithUID(uid)
+	return a.GetDashboardByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardByUIDWithParams(params *GetDashboardByUIDParams, opts ...ClientOption) (*GetDashboardByUIDOK, error) {
 	if params == nil {
 		params = NewGetDashboardByUIDParams()
 	}
@@ -176,7 +199,8 @@ func (a *Client) GetDashboardByUID(params *GetDashboardByUIDParams, opts ...Clie
 GetDashboardTags gets all dashboards tags of an organisation
 */
 func (a *Client) GetDashboardTags(opts ...ClientOption) (*GetDashboardTagsOK, error) {
-	return a.GetDashboardTagsWithParams(nil, opts...)
+	params := NewGetDashboardTagsParams()
+	return a.GetDashboardTagsWithParams(params, opts...)
 }
 
 func (a *Client) GetDashboardTagsWithParams(params *GetDashboardTagsParams, opts ...ClientOption) (*GetDashboardTagsOK, error) {
@@ -219,7 +243,8 @@ func (a *Client) GetDashboardTagsWithParams(params *GetDashboardTagsParams, opts
 GetHomeDashboard gets home dashboard
 */
 func (a *Client) GetHomeDashboard(opts ...ClientOption) (*GetHomeDashboardOK, error) {
-	return a.GetHomeDashboardWithParams(nil, opts...)
+	params := NewGetHomeDashboardParams()
+	return a.GetHomeDashboardWithParams(params, opts...)
 }
 
 func (a *Client) GetHomeDashboardWithParams(params *GetHomeDashboardParams, opts ...ClientOption) (*GetHomeDashboardOK, error) {
@@ -261,7 +286,12 @@ func (a *Client) GetHomeDashboardWithParams(params *GetHomeDashboardParams, opts
 /*
 ImportDashboard imports dashboard
 */
-func (a *Client) ImportDashboard(params *ImportDashboardParams, opts ...ClientOption) (*ImportDashboardOK, error) {
+func (a *Client) ImportDashboard(body *models.ImportDashboardRequest, opts ...ClientOption) (*ImportDashboardOK, error) {
+	params := NewImportDashboardParams().WithBody(body)
+	return a.ImportDashboardWithParams(params, opts...)
+}
+
+func (a *Client) ImportDashboardWithParams(params *ImportDashboardParams, opts ...ClientOption) (*ImportDashboardOK, error) {
 	if params == nil {
 		params = NewImportDashboardParams()
 	}
@@ -302,7 +332,12 @@ PostDashboard creates update dashboard
 
 Creates a new dashboard or updates an existing dashboard.
 */
-func (a *Client) PostDashboard(params *PostDashboardParams, opts ...ClientOption) (*PostDashboardOK, error) {
+func (a *Client) PostDashboard(body *models.SaveDashboardCommand, opts ...ClientOption) (*PostDashboardOK, error) {
+	params := NewPostDashboardParams().WithBody(body)
+	return a.PostDashboardWithParams(params, opts...)
+}
+
+func (a *Client) PostDashboardWithParams(params *PostDashboardParams, opts ...ClientOption) (*PostDashboardOK, error) {
 	if params == nil {
 		params = NewPostDashboardParams()
 	}
@@ -341,7 +376,12 @@ func (a *Client) PostDashboard(params *PostDashboardParams, opts ...ClientOption
 /*
 TrimDashboard trims defaults from dashboard
 */
-func (a *Client) TrimDashboard(params *TrimDashboardParams, opts ...ClientOption) (*TrimDashboardOK, error) {
+func (a *Client) TrimDashboard(body *models.TrimDashboardCommand, opts ...ClientOption) (*TrimDashboardOK, error) {
+	params := NewTrimDashboardParams().WithBody(body)
+	return a.TrimDashboardWithParams(params, opts...)
+}
+
+func (a *Client) TrimDashboardWithParams(params *TrimDashboardParams, opts ...ClientOption) (*TrimDashboardOK, error) {
 	if params == nil {
 		params = NewTrimDashboardParams()
 	}

--- a/client/datasource_permissions/datasource_permissions_client.go
+++ b/client/datasource_permissions/datasource_permissions_client.go
@@ -32,25 +32,30 @@ type ClientOption func(*runtime.ClientOperation)
 type ClientService interface {
 	AddPermission(params *AddPermissionParams, opts ...ClientOption) (*AddPermissionOK, error)
 
-	DeletePermissions(params *DeletePermissionsParams, opts ...ClientOption) (*DeletePermissionsOK, error)
+	DeletePermissions(permissionID string, datasourceID string, opts ...ClientOption) (*DeletePermissionsOK, error)
+	DeletePermissionsWithParams(params *DeletePermissionsParams, opts ...ClientOption) (*DeletePermissionsOK, error)
 
-	DisablePermissions(params *DisablePermissionsParams, opts ...ClientOption) (*DisablePermissionsOK, error)
+	DisablePermissions(datasourceID string, opts ...ClientOption) (*DisablePermissionsOK, error)
+	DisablePermissionsWithParams(params *DisablePermissionsParams, opts ...ClientOption) (*DisablePermissionsOK, error)
 
-	EnablePermissions(params *EnablePermissionsParams, opts ...ClientOption) (*EnablePermissionsOK, error)
+	EnablePermissions(datasourceID string, opts ...ClientOption) (*EnablePermissionsOK, error)
+	EnablePermissionsWithParams(params *EnablePermissionsParams, opts ...ClientOption) (*EnablePermissionsOK, error)
 
-	GetAllPermissions(params *GetAllPermissionsParams, opts ...ClientOption) (*GetAllPermissionsOK, error)
+	GetAllPermissions(datasourceID string, opts ...ClientOption) (*GetAllPermissionsOK, error)
+	GetAllPermissionsWithParams(params *GetAllPermissionsParams, opts ...ClientOption) (*GetAllPermissionsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
 
 /*
-	AddPermission adds permissions for a data source
+AddPermission adds permissions for a data source
 
-	You need to have a permission with action `datasources.permissions:read` and scopes `datasources:*`, `datasources:id:*`, `datasources:id:1` (single data source).
+You need to have a permission with action `datasources.permissions:read` and scopes `datasources:*`, `datasources:id:*`, `datasources:id:1` (single data source).
 
 Deprecated: true.
 Deprecated. Please use POST /api/access-control/datasources/:uid/users/:id, /api/access-control/datasources/:uid/teams/:id or /api/access-control/datasources/:uid/buildInRoles/:id
 */
+
 func (a *Client) AddPermission(params *AddPermissionParams, opts ...ClientOption) (*AddPermissionOK, error) {
 	if params == nil {
 		params = NewAddPermissionParams()
@@ -88,16 +93,21 @@ func (a *Client) AddPermission(params *AddPermissionParams, opts ...ClientOption
 }
 
 /*
-	DeletePermissions removes permission for a data source
+DeletePermissions removes permission for a data source
 
-	Removes the permission with the given permissionId for the data source with the given id.
+Removes the permission with the given permissionId for the data source with the given id.
 
 You need to have a permission with action `datasources.permissions:delete` and scopes `datasources:*`, `datasources:id:*`, `datasources:id:1` (single data source).
 
 Deprecated: true.
 Deprecated. Please use POST /api/access-control/datasources/:uid/users/:id, /api/access-control/datasources/:uid/teams/:id or /api/access-control/datasources/:uid/buildInRoles/:id
 */
-func (a *Client) DeletePermissions(params *DeletePermissionsParams, opts ...ClientOption) (*DeletePermissionsOK, error) {
+func (a *Client) DeletePermissions(permissionID string, datasourceID string, opts ...ClientOption) (*DeletePermissionsOK, error) {
+	params := NewDeletePermissionsParams().WithDatasourceID(datasourceID).WithPermissionID(permissionID)
+	return a.DeletePermissionsWithParams(params, opts...)
+}
+
+func (a *Client) DeletePermissionsWithParams(params *DeletePermissionsParams, opts ...ClientOption) (*DeletePermissionsOK, error) {
 	if params == nil {
 		params = NewDeletePermissionsParams()
 	}
@@ -134,15 +144,20 @@ func (a *Client) DeletePermissions(params *DeletePermissionsParams, opts ...Clie
 }
 
 /*
-	DisablePermissions disables permissions for a data source
+DisablePermissions disables permissions for a data source
 
-	Disables permissions for the data source with the given id. All existing permissions will be removed and anyone will be able to query the data source.
+Disables permissions for the data source with the given id. All existing permissions will be removed and anyone will be able to query the data source.
 
 You need to have a permission with action `datasources.permissions:toggle` and scopes `datasources:*`, `datasources:id:*`, `datasources:id:1` (single data source).
 
 Deprecated: true.
 */
-func (a *Client) DisablePermissions(params *DisablePermissionsParams, opts ...ClientOption) (*DisablePermissionsOK, error) {
+func (a *Client) DisablePermissions(datasourceID string, opts ...ClientOption) (*DisablePermissionsOK, error) {
+	params := NewDisablePermissionsParams().WithDatasourceID(datasourceID)
+	return a.DisablePermissionsWithParams(params, opts...)
+}
+
+func (a *Client) DisablePermissionsWithParams(params *DisablePermissionsParams, opts ...ClientOption) (*DisablePermissionsOK, error) {
 	if params == nil {
 		params = NewDisablePermissionsParams()
 	}
@@ -179,10 +194,9 @@ func (a *Client) DisablePermissions(params *DisablePermissionsParams, opts ...Cl
 }
 
 /*
-	EnablePermissions enables permissions for a data source
+EnablePermissions enables permissions for a data source
 
-	Enables permissions for the data source with the given id.
-
+Enables permissions for the data source with the given id.
 No one except Org Admins will be able to query the data source until permissions have been added
 which permit certain users or teams to query the data source.
 
@@ -190,7 +204,12 @@ You need to have a permission with action `datasources.permissions:toggle` and s
 
 Deprecated: true.
 */
-func (a *Client) EnablePermissions(params *EnablePermissionsParams, opts ...ClientOption) (*EnablePermissionsOK, error) {
+func (a *Client) EnablePermissions(datasourceID string, opts ...ClientOption) (*EnablePermissionsOK, error) {
+	params := NewEnablePermissionsParams().WithDatasourceID(datasourceID)
+	return a.EnablePermissionsWithParams(params, opts...)
+}
+
+func (a *Client) EnablePermissionsWithParams(params *EnablePermissionsParams, opts ...ClientOption) (*EnablePermissionsOK, error) {
 	if params == nil {
 		params = NewEnablePermissionsParams()
 	}
@@ -227,16 +246,21 @@ func (a *Client) EnablePermissions(params *EnablePermissionsParams, opts ...Clie
 }
 
 /*
-	GetAllPermissions gets permissions for a data source
+GetAllPermissions gets permissions for a data source
 
-	Gets all existing permissions for the data source with the given id.
+Gets all existing permissions for the data source with the given id.
 
 You need to have a permission with action `datasources.permissions:read` and scopes `datasources:*`, `datasources:id:*`, `datasources:id:1` (single data source).
 
 Deprecated: true.
 Deprecated. Please use GET /api/access-control/datasources/:uid
 */
-func (a *Client) GetAllPermissions(params *GetAllPermissionsParams, opts ...ClientOption) (*GetAllPermissionsOK, error) {
+func (a *Client) GetAllPermissions(datasourceID string, opts ...ClientOption) (*GetAllPermissionsOK, error) {
+	params := NewGetAllPermissionsParams().WithDatasourceID(datasourceID)
+	return a.GetAllPermissionsWithParams(params, opts...)
+}
+
+func (a *Client) GetAllPermissionsWithParams(params *GetAllPermissionsParams, opts ...ClientOption) (*GetAllPermissionsOK, error) {
 	if params == nil {
 		params = NewGetAllPermissionsParams()
 	}

--- a/client/datasources/datasources_client.go
+++ b/client/datasources/datasources_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new datasources API client.
@@ -30,64 +32,86 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddDataSource(params *AddDataSourceParams, opts ...ClientOption) (*AddDataSourceOK, error)
+	AddDataSource(body *models.AddDataSourceCommand, opts ...ClientOption) (*AddDataSourceOK, error)
+	AddDataSourceWithParams(params *AddDataSourceParams, opts ...ClientOption) (*AddDataSourceOK, error)
 
-	CallDatasourceResourceByID(params *CallDatasourceResourceByIDParams, opts ...ClientOption) (*CallDatasourceResourceByIDOK, error)
+	CallDatasourceResourceByID(id string, datasourceProxyRoute string, opts ...ClientOption) (*CallDatasourceResourceByIDOK, error)
+	CallDatasourceResourceByIDWithParams(params *CallDatasourceResourceByIDParams, opts ...ClientOption) (*CallDatasourceResourceByIDOK, error)
 
-	CallDatasourceResourceWithUID(params *CallDatasourceResourceWithUIDParams, opts ...ClientOption) (*CallDatasourceResourceWithUIDOK, error)
+	CallDatasourceResourceWithUID(uid string, datasourceProxyRoute string, opts ...ClientOption) (*CallDatasourceResourceWithUIDOK, error)
+	CallDatasourceResourceWithUIDWithParams(params *CallDatasourceResourceWithUIDParams, opts ...ClientOption) (*CallDatasourceResourceWithUIDOK, error)
 
-	CheckDatasourceHealthByID(params *CheckDatasourceHealthByIDParams, opts ...ClientOption) (*CheckDatasourceHealthByIDOK, error)
+	CheckDatasourceHealthByID(id string, opts ...ClientOption) (*CheckDatasourceHealthByIDOK, error)
+	CheckDatasourceHealthByIDWithParams(params *CheckDatasourceHealthByIDParams, opts ...ClientOption) (*CheckDatasourceHealthByIDOK, error)
 
-	CheckDatasourceHealthWithUID(params *CheckDatasourceHealthWithUIDParams, opts ...ClientOption) (*CheckDatasourceHealthWithUIDOK, error)
+	CheckDatasourceHealthWithUID(uid string, opts ...ClientOption) (*CheckDatasourceHealthWithUIDOK, error)
+	CheckDatasourceHealthWithUIDWithParams(params *CheckDatasourceHealthWithUIDParams, opts ...ClientOption) (*CheckDatasourceHealthWithUIDOK, error)
 
-	DatasourceProxyDELETEByUIDcalls(params *DatasourceProxyDELETEByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEByUIDcallsAccepted, error)
+	DatasourceProxyDELETEByUIDcalls(uid string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyDELETEByUIDcallsAccepted, error)
+	DatasourceProxyDELETEByUIDcallsWithParams(params *DatasourceProxyDELETEByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEByUIDcallsAccepted, error)
 
-	DatasourceProxyDELETEcalls(params *DatasourceProxyDELETEcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEcallsAccepted, error)
+	DatasourceProxyDELETEcalls(id string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyDELETEcallsAccepted, error)
+	DatasourceProxyDELETEcallsWithParams(params *DatasourceProxyDELETEcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEcallsAccepted, error)
 
-	DatasourceProxyGETByUIDcalls(params *DatasourceProxyGETByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyGETByUIDcallsOK, error)
+	DatasourceProxyGETByUIDcalls(uid string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyGETByUIDcallsOK, error)
+	DatasourceProxyGETByUIDcallsWithParams(params *DatasourceProxyGETByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyGETByUIDcallsOK, error)
 
-	DatasourceProxyGETcalls(params *DatasourceProxyGETcallsParams, opts ...ClientOption) (*DatasourceProxyGETcallsOK, error)
+	DatasourceProxyGETcalls(id string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyGETcallsOK, error)
+	DatasourceProxyGETcallsWithParams(params *DatasourceProxyGETcallsParams, opts ...ClientOption) (*DatasourceProxyGETcallsOK, error)
 
 	DatasourceProxyPOSTByUIDcalls(params *DatasourceProxyPOSTByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyPOSTByUIDcallsCreated, *DatasourceProxyPOSTByUIDcallsAccepted, error)
 
 	DatasourceProxyPOSTcalls(params *DatasourceProxyPOSTcallsParams, opts ...ClientOption) (*DatasourceProxyPOSTcallsCreated, *DatasourceProxyPOSTcallsAccepted, error)
 
-	DeleteDataSourceByID(params *DeleteDataSourceByIDParams, opts ...ClientOption) (*DeleteDataSourceByIDOK, error)
+	DeleteDataSourceByID(id string, opts ...ClientOption) (*DeleteDataSourceByIDOK, error)
+	DeleteDataSourceByIDWithParams(params *DeleteDataSourceByIDParams, opts ...ClientOption) (*DeleteDataSourceByIDOK, error)
 
-	DeleteDataSourceByName(params *DeleteDataSourceByNameParams, opts ...ClientOption) (*DeleteDataSourceByNameOK, error)
+	DeleteDataSourceByName(name string, opts ...ClientOption) (*DeleteDataSourceByNameOK, error)
+	DeleteDataSourceByNameWithParams(params *DeleteDataSourceByNameParams, opts ...ClientOption) (*DeleteDataSourceByNameOK, error)
 
-	DeleteDataSourceByUID(params *DeleteDataSourceByUIDParams, opts ...ClientOption) (*DeleteDataSourceByUIDOK, error)
+	DeleteDataSourceByUID(uid string, opts ...ClientOption) (*DeleteDataSourceByUIDOK, error)
+	DeleteDataSourceByUIDWithParams(params *DeleteDataSourceByUIDParams, opts ...ClientOption) (*DeleteDataSourceByUIDOK, error)
 
-	GetDataSourceByID(params *GetDataSourceByIDParams, opts ...ClientOption) (*GetDataSourceByIDOK, error)
+	GetDataSourceByID(id string, opts ...ClientOption) (*GetDataSourceByIDOK, error)
+	GetDataSourceByIDWithParams(params *GetDataSourceByIDParams, opts ...ClientOption) (*GetDataSourceByIDOK, error)
 
-	GetDataSourceByName(params *GetDataSourceByNameParams, opts ...ClientOption) (*GetDataSourceByNameOK, error)
+	GetDataSourceByName(name string, opts ...ClientOption) (*GetDataSourceByNameOK, error)
+	GetDataSourceByNameWithParams(params *GetDataSourceByNameParams, opts ...ClientOption) (*GetDataSourceByNameOK, error)
 
-	GetDataSourceByUID(params *GetDataSourceByUIDParams, opts ...ClientOption) (*GetDataSourceByUIDOK, error)
+	GetDataSourceByUID(uid string, opts ...ClientOption) (*GetDataSourceByUIDOK, error)
+	GetDataSourceByUIDWithParams(params *GetDataSourceByUIDParams, opts ...ClientOption) (*GetDataSourceByUIDOK, error)
 
-	GetDataSourceIDByName(params *GetDataSourceIDByNameParams, opts ...ClientOption) (*GetDataSourceIDByNameOK, error)
+	GetDataSourceIDByName(name string, opts ...ClientOption) (*GetDataSourceIDByNameOK, error)
+	GetDataSourceIDByNameWithParams(params *GetDataSourceIDByNameParams, opts ...ClientOption) (*GetDataSourceIDByNameOK, error)
 
 	GetDataSources(opts ...ClientOption) (*GetDataSourcesOK, error)
 	GetDataSourcesWithParams(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error)
 
-	UpdateDataSourceByID(params *UpdateDataSourceByIDParams, opts ...ClientOption) (*UpdateDataSourceByIDOK, error)
+	UpdateDataSourceByID(id string, body *models.UpdateDataSourceCommand, opts ...ClientOption) (*UpdateDataSourceByIDOK, error)
+	UpdateDataSourceByIDWithParams(params *UpdateDataSourceByIDParams, opts ...ClientOption) (*UpdateDataSourceByIDOK, error)
 
-	UpdateDataSourceByUID(params *UpdateDataSourceByUIDParams, opts ...ClientOption) (*UpdateDataSourceByUIDOK, error)
+	UpdateDataSourceByUID(uid string, body *models.UpdateDataSourceCommand, opts ...ClientOption) (*UpdateDataSourceByUIDOK, error)
+	UpdateDataSourceByUIDWithParams(params *UpdateDataSourceByUIDParams, opts ...ClientOption) (*UpdateDataSourceByUIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
 
 /*
-	AddDataSource creates a data source
+AddDataSource creates a data source
 
-	By defining `password` and `basicAuthPassword` under secureJsonData property
-
+By defining `password` and `basicAuthPassword` under secureJsonData property
 Grafana encrypts them securely as an encrypted blob in the database.
 The response then lists the encrypted fields under secureJsonFields.
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:create`
 */
-func (a *Client) AddDataSource(params *AddDataSourceParams, opts ...ClientOption) (*AddDataSourceOK, error) {
+func (a *Client) AddDataSource(body *models.AddDataSourceCommand, opts ...ClientOption) (*AddDataSourceOK, error) {
+	params := NewAddDataSourceParams().WithBody(body)
+	return a.AddDataSourceWithParams(params, opts...)
+}
+
+func (a *Client) AddDataSourceWithParams(params *AddDataSourceParams, opts ...ClientOption) (*AddDataSourceOK, error) {
 	if params == nil {
 		params = NewAddDataSourceParams()
 	}
@@ -128,7 +152,12 @@ CallDatasourceResourceByID fetches data source resources by Id
 
 Please refer to [updated API](#/datasources/callDatasourceResourceWithUID) instead
 */
-func (a *Client) CallDatasourceResourceByID(params *CallDatasourceResourceByIDParams, opts ...ClientOption) (*CallDatasourceResourceByIDOK, error) {
+func (a *Client) CallDatasourceResourceByID(id string, datasourceProxyRoute string, opts ...ClientOption) (*CallDatasourceResourceByIDOK, error) {
+	params := NewCallDatasourceResourceByIDParams().WithDatasourceProxyRoute(datasourceProxyRoute).WithID(id)
+	return a.CallDatasourceResourceByIDWithParams(params, opts...)
+}
+
+func (a *Client) CallDatasourceResourceByIDWithParams(params *CallDatasourceResourceByIDParams, opts ...ClientOption) (*CallDatasourceResourceByIDOK, error) {
 	if params == nil {
 		params = NewCallDatasourceResourceByIDParams()
 	}
@@ -167,7 +196,12 @@ func (a *Client) CallDatasourceResourceByID(params *CallDatasourceResourceByIDPa
 /*
 CallDatasourceResourceWithUID fetches data source resources
 */
-func (a *Client) CallDatasourceResourceWithUID(params *CallDatasourceResourceWithUIDParams, opts ...ClientOption) (*CallDatasourceResourceWithUIDOK, error) {
+func (a *Client) CallDatasourceResourceWithUID(uid string, datasourceProxyRoute string, opts ...ClientOption) (*CallDatasourceResourceWithUIDOK, error) {
+	params := NewCallDatasourceResourceWithUIDParams().WithDatasourceProxyRoute(datasourceProxyRoute).WithUID(uid)
+	return a.CallDatasourceResourceWithUIDWithParams(params, opts...)
+}
+
+func (a *Client) CallDatasourceResourceWithUIDWithParams(params *CallDatasourceResourceWithUIDParams, opts ...ClientOption) (*CallDatasourceResourceWithUIDOK, error) {
 	if params == nil {
 		params = NewCallDatasourceResourceWithUIDParams()
 	}
@@ -208,7 +242,12 @@ CheckDatasourceHealthByID sends a health check request to the plugin datasource 
 
 Please refer to [updated API](#/datasources/checkDatasourceHealthWithUID) instead
 */
-func (a *Client) CheckDatasourceHealthByID(params *CheckDatasourceHealthByIDParams, opts ...ClientOption) (*CheckDatasourceHealthByIDOK, error) {
+func (a *Client) CheckDatasourceHealthByID(id string, opts ...ClientOption) (*CheckDatasourceHealthByIDOK, error) {
+	params := NewCheckDatasourceHealthByIDParams().WithID(id)
+	return a.CheckDatasourceHealthByIDWithParams(params, opts...)
+}
+
+func (a *Client) CheckDatasourceHealthByIDWithParams(params *CheckDatasourceHealthByIDParams, opts ...ClientOption) (*CheckDatasourceHealthByIDOK, error) {
 	if params == nil {
 		params = NewCheckDatasourceHealthByIDParams()
 	}
@@ -247,7 +286,12 @@ func (a *Client) CheckDatasourceHealthByID(params *CheckDatasourceHealthByIDPara
 /*
 CheckDatasourceHealthWithUID sends a health check request to the plugin datasource identified by the UID
 */
-func (a *Client) CheckDatasourceHealthWithUID(params *CheckDatasourceHealthWithUIDParams, opts ...ClientOption) (*CheckDatasourceHealthWithUIDOK, error) {
+func (a *Client) CheckDatasourceHealthWithUID(uid string, opts ...ClientOption) (*CheckDatasourceHealthWithUIDOK, error) {
+	params := NewCheckDatasourceHealthWithUIDParams().WithUID(uid)
+	return a.CheckDatasourceHealthWithUIDWithParams(params, opts...)
+}
+
+func (a *Client) CheckDatasourceHealthWithUIDWithParams(params *CheckDatasourceHealthWithUIDParams, opts ...ClientOption) (*CheckDatasourceHealthWithUIDOK, error) {
 	if params == nil {
 		params = NewCheckDatasourceHealthWithUIDParams()
 	}
@@ -288,7 +332,12 @@ DatasourceProxyDELETEByUIDcalls data source proxy d e l e t e calls
 
 Proxies all calls to the actual data source.
 */
-func (a *Client) DatasourceProxyDELETEByUIDcalls(params *DatasourceProxyDELETEByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEByUIDcallsAccepted, error) {
+func (a *Client) DatasourceProxyDELETEByUIDcalls(uid string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyDELETEByUIDcallsAccepted, error) {
+	params := NewDatasourceProxyDELETEByUIDcallsParams().WithDatasourceProxyRoute(datasourceProxyRoute).WithUID(uid)
+	return a.DatasourceProxyDELETEByUIDcallsWithParams(params, opts...)
+}
+
+func (a *Client) DatasourceProxyDELETEByUIDcallsWithParams(params *DatasourceProxyDELETEByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEByUIDcallsAccepted, error) {
 	if params == nil {
 		params = NewDatasourceProxyDELETEByUIDcallsParams()
 	}
@@ -325,13 +374,18 @@ func (a *Client) DatasourceProxyDELETEByUIDcalls(params *DatasourceProxyDELETEBy
 }
 
 /*
-	DatasourceProxyDELETEcalls data source proxy d e l e t e calls
+DatasourceProxyDELETEcalls data source proxy d e l e t e calls
 
-	Proxies all calls to the actual data source.
+Proxies all calls to the actual data source.
 
 Please refer to [updated API](#/datasources/datasourceProxyDELETEByUIDcalls) instead
 */
-func (a *Client) DatasourceProxyDELETEcalls(params *DatasourceProxyDELETEcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEcallsAccepted, error) {
+func (a *Client) DatasourceProxyDELETEcalls(id string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyDELETEcallsAccepted, error) {
+	params := NewDatasourceProxyDELETEcallsParams().WithDatasourceProxyRoute(datasourceProxyRoute).WithID(id)
+	return a.DatasourceProxyDELETEcallsWithParams(params, opts...)
+}
+
+func (a *Client) DatasourceProxyDELETEcallsWithParams(params *DatasourceProxyDELETEcallsParams, opts ...ClientOption) (*DatasourceProxyDELETEcallsAccepted, error) {
 	if params == nil {
 		params = NewDatasourceProxyDELETEcallsParams()
 	}
@@ -372,7 +426,12 @@ DatasourceProxyGETByUIDcalls data source proxy g e t calls
 
 Proxies all calls to the actual data source.
 */
-func (a *Client) DatasourceProxyGETByUIDcalls(params *DatasourceProxyGETByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyGETByUIDcallsOK, error) {
+func (a *Client) DatasourceProxyGETByUIDcalls(uid string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyGETByUIDcallsOK, error) {
+	params := NewDatasourceProxyGETByUIDcallsParams().WithDatasourceProxyRoute(datasourceProxyRoute).WithUID(uid)
+	return a.DatasourceProxyGETByUIDcallsWithParams(params, opts...)
+}
+
+func (a *Client) DatasourceProxyGETByUIDcallsWithParams(params *DatasourceProxyGETByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyGETByUIDcallsOK, error) {
 	if params == nil {
 		params = NewDatasourceProxyGETByUIDcallsParams()
 	}
@@ -409,13 +468,18 @@ func (a *Client) DatasourceProxyGETByUIDcalls(params *DatasourceProxyGETByUIDcal
 }
 
 /*
-	DatasourceProxyGETcalls data source proxy g e t calls
+DatasourceProxyGETcalls data source proxy g e t calls
 
-	Proxies all calls to the actual data source.
+Proxies all calls to the actual data source.
 
 Please refer to [updated API](#/datasources/datasourceProxyGETByUIDcalls) instead
 */
-func (a *Client) DatasourceProxyGETcalls(params *DatasourceProxyGETcallsParams, opts ...ClientOption) (*DatasourceProxyGETcallsOK, error) {
+func (a *Client) DatasourceProxyGETcalls(id string, datasourceProxyRoute string, opts ...ClientOption) (*DatasourceProxyGETcallsOK, error) {
+	params := NewDatasourceProxyGETcallsParams().WithDatasourceProxyRoute(datasourceProxyRoute).WithID(id)
+	return a.DatasourceProxyGETcallsWithParams(params, opts...)
+}
+
+func (a *Client) DatasourceProxyGETcallsWithParams(params *DatasourceProxyGETcallsParams, opts ...ClientOption) (*DatasourceProxyGETcallsOK, error) {
 	if params == nil {
 		params = NewDatasourceProxyGETcallsParams()
 	}
@@ -456,6 +520,7 @@ DatasourceProxyPOSTByUIDcalls data source proxy p o s t calls
 
 Proxies all calls to the actual data source. The data source should support POST methods for the specific path and role as defined
 */
+
 func (a *Client) DatasourceProxyPOSTByUIDcalls(params *DatasourceProxyPOSTByUIDcallsParams, opts ...ClientOption) (*DatasourceProxyPOSTByUIDcallsCreated, *DatasourceProxyPOSTByUIDcallsAccepted, error) {
 	if params == nil {
 		params = NewDatasourceProxyPOSTByUIDcallsParams()
@@ -494,12 +559,13 @@ func (a *Client) DatasourceProxyPOSTByUIDcalls(params *DatasourceProxyPOSTByUIDc
 }
 
 /*
-	DatasourceProxyPOSTcalls data source proxy p o s t calls
+DatasourceProxyPOSTcalls data source proxy p o s t calls
 
-	Proxies all calls to the actual data source. The data source should support POST methods for the specific path and role as defined
+Proxies all calls to the actual data source. The data source should support POST methods for the specific path and role as defined
 
 Please refer to [updated API](#/datasources/datasourceProxyPOSTByUIDcalls) instead
 */
+
 func (a *Client) DatasourceProxyPOSTcalls(params *DatasourceProxyPOSTcallsParams, opts ...ClientOption) (*DatasourceProxyPOSTcallsCreated, *DatasourceProxyPOSTcallsAccepted, error) {
 	if params == nil {
 		params = NewDatasourceProxyPOSTcallsParams()
@@ -538,15 +604,19 @@ func (a *Client) DatasourceProxyPOSTcalls(params *DatasourceProxyPOSTcallsParams
 }
 
 /*
-	DeleteDataSourceByID deletes an existing data source by id
+DeleteDataSourceByID deletes an existing data source by id
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:delete` and scopes: `datasources:*`, `datasources:id:*` and `datasources:id:1` (single data source).
 
 Please refer to [updated API](#/datasources/deleteDataSourceByUID) instead
 */
-func (a *Client) DeleteDataSourceByID(params *DeleteDataSourceByIDParams, opts ...ClientOption) (*DeleteDataSourceByIDOK, error) {
+func (a *Client) DeleteDataSourceByID(id string, opts ...ClientOption) (*DeleteDataSourceByIDOK, error) {
+	params := NewDeleteDataSourceByIDParams().WithID(id)
+	return a.DeleteDataSourceByIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteDataSourceByIDWithParams(params *DeleteDataSourceByIDParams, opts ...ClientOption) (*DeleteDataSourceByIDOK, error) {
 	if params == nil {
 		params = NewDeleteDataSourceByIDParams()
 	}
@@ -583,13 +653,17 @@ func (a *Client) DeleteDataSourceByID(params *DeleteDataSourceByIDParams, opts .
 }
 
 /*
-	DeleteDataSourceByName deletes an existing data source by name
+DeleteDataSourceByName deletes an existing data source by name
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:delete` and scopes: `datasources:*`, `datasources:name:*` and `datasources:name:test_datasource` (single data source).
 */
-func (a *Client) DeleteDataSourceByName(params *DeleteDataSourceByNameParams, opts ...ClientOption) (*DeleteDataSourceByNameOK, error) {
+func (a *Client) DeleteDataSourceByName(name string, opts ...ClientOption) (*DeleteDataSourceByNameOK, error) {
+	params := NewDeleteDataSourceByNameParams().WithName(name)
+	return a.DeleteDataSourceByNameWithParams(params, opts...)
+}
+
+func (a *Client) DeleteDataSourceByNameWithParams(params *DeleteDataSourceByNameParams, opts ...ClientOption) (*DeleteDataSourceByNameOK, error) {
 	if params == nil {
 		params = NewDeleteDataSourceByNameParams()
 	}
@@ -626,13 +700,17 @@ func (a *Client) DeleteDataSourceByName(params *DeleteDataSourceByNameParams, op
 }
 
 /*
-	DeleteDataSourceByUID deletes an existing data source by UID
+DeleteDataSourceByUID deletes an existing data source by UID
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:delete` and scopes: `datasources:*`, `datasources:uid:*` and `datasources:uid:kLtEtcRGk` (single data source).
 */
-func (a *Client) DeleteDataSourceByUID(params *DeleteDataSourceByUIDParams, opts ...ClientOption) (*DeleteDataSourceByUIDOK, error) {
+func (a *Client) DeleteDataSourceByUID(uid string, opts ...ClientOption) (*DeleteDataSourceByUIDOK, error) {
+	params := NewDeleteDataSourceByUIDParams().WithUID(uid)
+	return a.DeleteDataSourceByUIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteDataSourceByUIDWithParams(params *DeleteDataSourceByUIDParams, opts ...ClientOption) (*DeleteDataSourceByUIDOK, error) {
 	if params == nil {
 		params = NewDeleteDataSourceByUIDParams()
 	}
@@ -669,15 +747,19 @@ func (a *Client) DeleteDataSourceByUID(params *DeleteDataSourceByUIDParams, opts
 }
 
 /*
-	GetDataSourceByID gets a single data source by Id
+GetDataSourceByID gets a single data source by Id
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:read` and scopes: `datasources:*`, `datasources:id:*` and `datasources:id:1` (single data source).
 
 Please refer to [updated API](#/datasources/getDataSourceByUID) instead
 */
-func (a *Client) GetDataSourceByID(params *GetDataSourceByIDParams, opts ...ClientOption) (*GetDataSourceByIDOK, error) {
+func (a *Client) GetDataSourceByID(id string, opts ...ClientOption) (*GetDataSourceByIDOK, error) {
+	params := NewGetDataSourceByIDParams().WithID(id)
+	return a.GetDataSourceByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDataSourceByIDWithParams(params *GetDataSourceByIDParams, opts ...ClientOption) (*GetDataSourceByIDOK, error) {
 	if params == nil {
 		params = NewGetDataSourceByIDParams()
 	}
@@ -714,13 +796,17 @@ func (a *Client) GetDataSourceByID(params *GetDataSourceByIDParams, opts ...Clie
 }
 
 /*
-	GetDataSourceByName gets a single data source by name
+GetDataSourceByName gets a single data source by name
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:read` and scopes: `datasources:*`, `datasources:name:*` and `datasources:name:test_datasource` (single data source).
 */
-func (a *Client) GetDataSourceByName(params *GetDataSourceByNameParams, opts ...ClientOption) (*GetDataSourceByNameOK, error) {
+func (a *Client) GetDataSourceByName(name string, opts ...ClientOption) (*GetDataSourceByNameOK, error) {
+	params := NewGetDataSourceByNameParams().WithName(name)
+	return a.GetDataSourceByNameWithParams(params, opts...)
+}
+
+func (a *Client) GetDataSourceByNameWithParams(params *GetDataSourceByNameParams, opts ...ClientOption) (*GetDataSourceByNameOK, error) {
 	if params == nil {
 		params = NewGetDataSourceByNameParams()
 	}
@@ -757,13 +843,17 @@ func (a *Client) GetDataSourceByName(params *GetDataSourceByNameParams, opts ...
 }
 
 /*
-	GetDataSourceByUID gets a single data source by UID
+GetDataSourceByUID gets a single data source by UID
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:read` and scopes: `datasources:*`, `datasources:uid:*` and `datasources:uid:kLtEtcRGk` (single data source).
 */
-func (a *Client) GetDataSourceByUID(params *GetDataSourceByUIDParams, opts ...ClientOption) (*GetDataSourceByUIDOK, error) {
+func (a *Client) GetDataSourceByUID(uid string, opts ...ClientOption) (*GetDataSourceByUIDOK, error) {
+	params := NewGetDataSourceByUIDParams().WithUID(uid)
+	return a.GetDataSourceByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetDataSourceByUIDWithParams(params *GetDataSourceByUIDParams, opts ...ClientOption) (*GetDataSourceByUIDOK, error) {
 	if params == nil {
 		params = NewGetDataSourceByUIDParams()
 	}
@@ -800,13 +890,17 @@ func (a *Client) GetDataSourceByUID(params *GetDataSourceByUIDParams, opts ...Cl
 }
 
 /*
-	GetDataSourceIDByName gets data source Id by name
+GetDataSourceIDByName gets data source Id by name
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:read` and scopes: `datasources:*`, `datasources:name:*` and `datasources:name:test_datasource` (single data source).
 */
-func (a *Client) GetDataSourceIDByName(params *GetDataSourceIDByNameParams, opts ...ClientOption) (*GetDataSourceIDByNameOK, error) {
+func (a *Client) GetDataSourceIDByName(name string, opts ...ClientOption) (*GetDataSourceIDByNameOK, error) {
+	params := NewGetDataSourceIDByNameParams().WithName(name)
+	return a.GetDataSourceIDByNameWithParams(params, opts...)
+}
+
+func (a *Client) GetDataSourceIDByNameWithParams(params *GetDataSourceIDByNameParams, opts ...ClientOption) (*GetDataSourceIDByNameOK, error) {
 	if params == nil {
 		params = NewGetDataSourceIDByNameParams()
 	}
@@ -843,14 +937,14 @@ func (a *Client) GetDataSourceIDByName(params *GetDataSourceIDByNameParams, opts
 }
 
 /*
-	GetDataSources gets all data sources
+GetDataSources gets all data sources
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:read` and scope: `datasources:*`.
 */
 func (a *Client) GetDataSources(opts ...ClientOption) (*GetDataSourcesOK, error) {
-	return a.GetDataSourcesWithParams(nil, opts...)
+	params := NewGetDataSourcesParams()
+	return a.GetDataSourcesWithParams(params, opts...)
 }
 
 func (a *Client) GetDataSourcesWithParams(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error) {
@@ -890,10 +984,9 @@ func (a *Client) GetDataSourcesWithParams(params *GetDataSourcesParams, opts ...
 }
 
 /*
-	UpdateDataSourceByID updates an existing data source by its sequential ID
+UpdateDataSourceByID updates an existing data source by its sequential ID
 
-	Similar to creating a data source, `password` and `basicAuthPassword` should be defined under
-
+Similar to creating a data source, `password` and `basicAuthPassword` should be defined under
 secureJsonData in order to be stored securely as an encrypted blob in the database. Then, the
 encrypted fields are listed under secureJsonFields section in the response.
 
@@ -902,7 +995,12 @@ you need to have a permission with action: `datasources:write` and scopes: `data
 
 Please refer to [updated API](#/datasources/updateDataSourceByUID) instead
 */
-func (a *Client) UpdateDataSourceByID(params *UpdateDataSourceByIDParams, opts ...ClientOption) (*UpdateDataSourceByIDOK, error) {
+func (a *Client) UpdateDataSourceByID(id string, body *models.UpdateDataSourceCommand, opts ...ClientOption) (*UpdateDataSourceByIDOK, error) {
+	params := NewUpdateDataSourceByIDParams().WithBody(body).WithID(id)
+	return a.UpdateDataSourceByIDWithParams(params, opts...)
+}
+
+func (a *Client) UpdateDataSourceByIDWithParams(params *UpdateDataSourceByIDParams, opts ...ClientOption) (*UpdateDataSourceByIDOK, error) {
 	if params == nil {
 		params = NewUpdateDataSourceByIDParams()
 	}
@@ -939,17 +1037,21 @@ func (a *Client) UpdateDataSourceByID(params *UpdateDataSourceByIDParams, opts .
 }
 
 /*
-	UpdateDataSourceByUID updates an existing data source
+UpdateDataSourceByUID updates an existing data source
 
-	Similar to creating a data source, `password` and `basicAuthPassword` should be defined under
-
+Similar to creating a data source, `password` and `basicAuthPassword` should be defined under
 secureJsonData in order to be stored securely as an encrypted blob in the database. Then, the
 encrypted fields are listed under secureJsonFields section in the response.
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:write` and scopes: `datasources:*`, `datasources:uid:*` and `datasources:uid:1` (single data source).
 */
-func (a *Client) UpdateDataSourceByUID(params *UpdateDataSourceByUIDParams, opts ...ClientOption) (*UpdateDataSourceByUIDOK, error) {
+func (a *Client) UpdateDataSourceByUID(uid string, body *models.UpdateDataSourceCommand, opts ...ClientOption) (*UpdateDataSourceByUIDOK, error) {
+	params := NewUpdateDataSourceByUIDParams().WithBody(body).WithUID(uid)
+	return a.UpdateDataSourceByUIDWithParams(params, opts...)
+}
+
+func (a *Client) UpdateDataSourceByUIDWithParams(params *UpdateDataSourceByUIDParams, opts ...ClientOption) (*UpdateDataSourceByUIDOK, error) {
 	if params == nil {
 		params = NewUpdateDataSourceByUIDParams()
 	}

--- a/client/ds/ds_client.go
+++ b/client/ds/ds_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new ds API client.
@@ -30,19 +32,24 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	QueryMetricsWithExpressions(params *QueryMetricsWithExpressionsParams, opts ...ClientOption) (*QueryMetricsWithExpressionsOK, *QueryMetricsWithExpressionsMultiStatus, error)
+	QueryMetricsWithExpressions(body *models.MetricRequest, opts ...ClientOption) (*QueryMetricsWithExpressionsOK, *QueryMetricsWithExpressionsMultiStatus, error)
+	QueryMetricsWithExpressionsWithParams(params *QueryMetricsWithExpressionsParams, opts ...ClientOption) (*QueryMetricsWithExpressionsOK, *QueryMetricsWithExpressionsMultiStatus, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
 
 /*
-	QueryMetricsWithExpressions data source query metrics with expressions
+QueryMetricsWithExpressions data source query metrics with expressions
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `datasources:query`.
 */
-func (a *Client) QueryMetricsWithExpressions(params *QueryMetricsWithExpressionsParams, opts ...ClientOption) (*QueryMetricsWithExpressionsOK, *QueryMetricsWithExpressionsMultiStatus, error) {
+func (a *Client) QueryMetricsWithExpressions(body *models.MetricRequest, opts ...ClientOption) (*QueryMetricsWithExpressionsOK, *QueryMetricsWithExpressionsMultiStatus, error) {
+	params := NewQueryMetricsWithExpressionsParams().WithBody(body)
+	return a.QueryMetricsWithExpressionsWithParams(params, opts...)
+}
+
+func (a *Client) QueryMetricsWithExpressionsWithParams(params *QueryMetricsWithExpressionsParams, opts ...ClientOption) (*QueryMetricsWithExpressionsOK, *QueryMetricsWithExpressionsMultiStatus, error) {
 	if params == nil {
 		params = NewQueryMetricsWithExpressionsParams()
 	}

--- a/client/enterprise/enterprise_client.go
+++ b/client/enterprise/enterprise_client.go
@@ -37,15 +37,16 @@ type ClientService interface {
 }
 
 /*
-	SearchResult debugs permissions
+SearchResult debugs permissions
 
-	Returns the result of the search through access-control role assignments.
+Returns the result of the search through access-control role assignments.
 
 You need to have a permission with action `teams.roles:read` on scope `teams:*`
 and a permission with action `users.roles:read` on scope `users:*`.
 */
 func (a *Client) SearchResult(opts ...ClientOption) (*SearchResultOK, error) {
-	return a.SearchResultWithParams(nil, opts...)
+	params := NewSearchResultParams()
+	return a.SearchResultWithParams(params, opts...)
 }
 
 func (a *Client) SearchResultWithParams(params *SearchResultParams, opts ...ClientOption) (*SearchResultOK, error) {

--- a/client/folder_permissions/folder_permissions_client.go
+++ b/client/folder_permissions/folder_permissions_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new folder permissions API client.
@@ -30,9 +32,11 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetFolderPermissionList(params *GetFolderPermissionListParams, opts ...ClientOption) (*GetFolderPermissionListOK, error)
+	GetFolderPermissionList(folderUID string, opts ...ClientOption) (*GetFolderPermissionListOK, error)
+	GetFolderPermissionListWithParams(params *GetFolderPermissionListParams, opts ...ClientOption) (*GetFolderPermissionListOK, error)
 
-	UpdateFolderPermissions(params *UpdateFolderPermissionsParams, opts ...ClientOption) (*UpdateFolderPermissionsOK, error)
+	UpdateFolderPermissions(folderUID string, body *models.UpdateDashboardACLCommand, opts ...ClientOption) (*UpdateFolderPermissionsOK, error)
+	UpdateFolderPermissionsWithParams(params *UpdateFolderPermissionsParams, opts ...ClientOption) (*UpdateFolderPermissionsOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -40,7 +44,12 @@ type ClientService interface {
 /*
 GetFolderPermissionList gets all existing permissions for the folder with the given uid
 */
-func (a *Client) GetFolderPermissionList(params *GetFolderPermissionListParams, opts ...ClientOption) (*GetFolderPermissionListOK, error) {
+func (a *Client) GetFolderPermissionList(folderUID string, opts ...ClientOption) (*GetFolderPermissionListOK, error) {
+	params := NewGetFolderPermissionListParams().WithFolderUID(folderUID)
+	return a.GetFolderPermissionListWithParams(params, opts...)
+}
+
+func (a *Client) GetFolderPermissionListWithParams(params *GetFolderPermissionListParams, opts ...ClientOption) (*GetFolderPermissionListOK, error) {
 	if params == nil {
 		params = NewGetFolderPermissionListParams()
 	}
@@ -79,7 +88,12 @@ func (a *Client) GetFolderPermissionList(params *GetFolderPermissionListParams, 
 /*
 UpdateFolderPermissions updates permissions for a folder this operation will remove existing permissions if they re not included in the request
 */
-func (a *Client) UpdateFolderPermissions(params *UpdateFolderPermissionsParams, opts ...ClientOption) (*UpdateFolderPermissionsOK, error) {
+func (a *Client) UpdateFolderPermissions(folderUID string, body *models.UpdateDashboardACLCommand, opts ...ClientOption) (*UpdateFolderPermissionsOK, error) {
+	params := NewUpdateFolderPermissionsParams().WithBody(body).WithFolderUID(folderUID)
+	return a.UpdateFolderPermissionsWithParams(params, opts...)
+}
+
+func (a *Client) UpdateFolderPermissionsWithParams(params *UpdateFolderPermissionsParams, opts ...ClientOption) (*UpdateFolderPermissionsOK, error) {
 	if params == nil {
 		params = NewUpdateFolderPermissionsParams()
 	}

--- a/client/folders/folders_client.go
+++ b/client/folders/folders_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new folders API client.
@@ -30,21 +32,27 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateFolder(params *CreateFolderParams, opts ...ClientOption) (*CreateFolderOK, error)
+	CreateFolder(body *models.CreateFolderCommand, opts ...ClientOption) (*CreateFolderOK, error)
+	CreateFolderWithParams(params *CreateFolderParams, opts ...ClientOption) (*CreateFolderOK, error)
 
 	DeleteFolder(params *DeleteFolderParams, opts ...ClientOption) (*DeleteFolderOK, error)
 
-	GetFolderByID(params *GetFolderByIDParams, opts ...ClientOption) (*GetFolderByIDOK, error)
+	GetFolderByID(folderID int64, opts ...ClientOption) (*GetFolderByIDOK, error)
+	GetFolderByIDWithParams(params *GetFolderByIDParams, opts ...ClientOption) (*GetFolderByIDOK, error)
 
-	GetFolderByUID(params *GetFolderByUIDParams, opts ...ClientOption) (*GetFolderByUIDOK, error)
+	GetFolderByUID(folderUID string, opts ...ClientOption) (*GetFolderByUIDOK, error)
+	GetFolderByUIDWithParams(params *GetFolderByUIDParams, opts ...ClientOption) (*GetFolderByUIDOK, error)
 
-	GetFolderDescendantCounts(params *GetFolderDescendantCountsParams, opts ...ClientOption) (*GetFolderDescendantCountsOK, error)
+	GetFolderDescendantCounts(folderUID string, opts ...ClientOption) (*GetFolderDescendantCountsOK, error)
+	GetFolderDescendantCountsWithParams(params *GetFolderDescendantCountsParams, opts ...ClientOption) (*GetFolderDescendantCountsOK, error)
 
 	GetFolders(params *GetFoldersParams, opts ...ClientOption) (*GetFoldersOK, error)
 
-	MoveFolder(params *MoveFolderParams, opts ...ClientOption) (*MoveFolderOK, error)
+	MoveFolder(folderUID string, body *models.MoveFolderCommand, opts ...ClientOption) (*MoveFolderOK, error)
+	MoveFolderWithParams(params *MoveFolderParams, opts ...ClientOption) (*MoveFolderOK, error)
 
-	UpdateFolder(params *UpdateFolderParams, opts ...ClientOption) (*UpdateFolderOK, error)
+	UpdateFolder(folderUID string, body *models.UpdateFolderCommand, opts ...ClientOption) (*UpdateFolderOK, error)
+	UpdateFolderWithParams(params *UpdateFolderParams, opts ...ClientOption) (*UpdateFolderOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -54,7 +62,12 @@ CreateFolder creates folder
 
 If nested folders are enabled then it additionally expects the parent folder UID.
 */
-func (a *Client) CreateFolder(params *CreateFolderParams, opts ...ClientOption) (*CreateFolderOK, error) {
+func (a *Client) CreateFolder(body *models.CreateFolderCommand, opts ...ClientOption) (*CreateFolderOK, error) {
+	params := NewCreateFolderParams().WithBody(body)
+	return a.CreateFolderWithParams(params, opts...)
+}
+
+func (a *Client) CreateFolderWithParams(params *CreateFolderParams, opts ...ClientOption) (*CreateFolderOK, error) {
 	if params == nil {
 		params = NewCreateFolderParams()
 	}
@@ -91,12 +104,12 @@ func (a *Client) CreateFolder(params *CreateFolderParams, opts ...ClientOption) 
 }
 
 /*
-	DeleteFolder deletes folder
+DeleteFolder deletes folder
 
-	Deletes an existing folder identified by UID along with all dashboards (and their alerts) stored in the folder. This operation cannot be reverted.
-
+Deletes an existing folder identified by UID along with all dashboards (and their alerts) stored in the folder. This operation cannot be reverted.
 If nested folders are enabled then it also deletes all the subfolders.
 */
+
 func (a *Client) DeleteFolder(params *DeleteFolderParams, opts ...ClientOption) (*DeleteFolderOK, error) {
 	if params == nil {
 		params = NewDeleteFolderParams()
@@ -134,13 +147,17 @@ func (a *Client) DeleteFolder(params *DeleteFolderParams, opts ...ClientOption) 
 }
 
 /*
-	GetFolderByID gets folder by id
+GetFolderByID gets folder by id
 
-	Returns the folder identified by id. This is deprecated.
-
+Returns the folder identified by id. This is deprecated.
 Please refer to [updated API](#/folders/getFolderByUID) instead
 */
-func (a *Client) GetFolderByID(params *GetFolderByIDParams, opts ...ClientOption) (*GetFolderByIDOK, error) {
+func (a *Client) GetFolderByID(folderID int64, opts ...ClientOption) (*GetFolderByIDOK, error) {
+	params := NewGetFolderByIDParams().WithFolderID(folderID)
+	return a.GetFolderByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetFolderByIDWithParams(params *GetFolderByIDParams, opts ...ClientOption) (*GetFolderByIDOK, error) {
 	if params == nil {
 		params = NewGetFolderByIDParams()
 	}
@@ -179,7 +196,12 @@ func (a *Client) GetFolderByID(params *GetFolderByIDParams, opts ...ClientOption
 /*
 GetFolderByUID gets folder by uid
 */
-func (a *Client) GetFolderByUID(params *GetFolderByUIDParams, opts ...ClientOption) (*GetFolderByUIDOK, error) {
+func (a *Client) GetFolderByUID(folderUID string, opts ...ClientOption) (*GetFolderByUIDOK, error) {
+	params := NewGetFolderByUIDParams().WithFolderUID(folderUID)
+	return a.GetFolderByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetFolderByUIDWithParams(params *GetFolderByUIDParams, opts ...ClientOption) (*GetFolderByUIDOK, error) {
 	if params == nil {
 		params = NewGetFolderByUIDParams()
 	}
@@ -218,7 +240,12 @@ func (a *Client) GetFolderByUID(params *GetFolderByUIDParams, opts ...ClientOpti
 /*
 GetFolderDescendantCounts gets the count of each descendant of a folder by kind the folder is identified by UID
 */
-func (a *Client) GetFolderDescendantCounts(params *GetFolderDescendantCountsParams, opts ...ClientOption) (*GetFolderDescendantCountsOK, error) {
+func (a *Client) GetFolderDescendantCounts(folderUID string, opts ...ClientOption) (*GetFolderDescendantCountsOK, error) {
+	params := NewGetFolderDescendantCountsParams().WithFolderUID(folderUID)
+	return a.GetFolderDescendantCountsWithParams(params, opts...)
+}
+
+func (a *Client) GetFolderDescendantCountsWithParams(params *GetFolderDescendantCountsParams, opts ...ClientOption) (*GetFolderDescendantCountsOK, error) {
 	if params == nil {
 		params = NewGetFolderDescendantCountsParams()
 	}
@@ -255,15 +282,15 @@ func (a *Client) GetFolderDescendantCounts(params *GetFolderDescendantCountsPara
 }
 
 /*
-	GetFolders gets all folders
+GetFolders gets all folders
 
-	Returns all folders that the authenticated user has permission to view.
-
+Returns all folders that the authenticated user has permission to view.
 If nested folders are enabled, it expects an additional query parameter with the parent folder UID
 and returns the immediate subfolders that the authenticated user has permission to view.
 If the parameter is not supplied then it returns immediate subfolders under the root
 that the authenticated user has permission to view.
 */
+
 func (a *Client) GetFolders(params *GetFoldersParams, opts ...ClientOption) (*GetFoldersOK, error) {
 	if params == nil {
 		params = NewGetFoldersParams()
@@ -303,7 +330,12 @@ func (a *Client) GetFolders(params *GetFoldersParams, opts ...ClientOption) (*Ge
 /*
 MoveFolder moves folder
 */
-func (a *Client) MoveFolder(params *MoveFolderParams, opts ...ClientOption) (*MoveFolderOK, error) {
+func (a *Client) MoveFolder(folderUID string, body *models.MoveFolderCommand, opts ...ClientOption) (*MoveFolderOK, error) {
+	params := NewMoveFolderParams().WithBody(body).WithFolderUID(folderUID)
+	return a.MoveFolderWithParams(params, opts...)
+}
+
+func (a *Client) MoveFolderWithParams(params *MoveFolderParams, opts ...ClientOption) (*MoveFolderOK, error) {
 	if params == nil {
 		params = NewMoveFolderParams()
 	}
@@ -342,7 +374,12 @@ func (a *Client) MoveFolder(params *MoveFolderParams, opts ...ClientOption) (*Mo
 /*
 UpdateFolder updates folder
 */
-func (a *Client) UpdateFolder(params *UpdateFolderParams, opts ...ClientOption) (*UpdateFolderOK, error) {
+func (a *Client) UpdateFolder(folderUID string, body *models.UpdateFolderCommand, opts ...ClientOption) (*UpdateFolderOK, error) {
+	params := NewUpdateFolderParams().WithBody(body).WithFolderUID(folderUID)
+	return a.UpdateFolderWithParams(params, opts...)
+}
+
+func (a *Client) UpdateFolderWithParams(params *UpdateFolderParams, opts ...ClientOption) (*UpdateFolderOK, error) {
 	if params == nil {
 		params = NewUpdateFolderParams()
 	}

--- a/client/get_current_org/get_current_org_client.go
+++ b/client/get_current_org/get_current_org_client.go
@@ -42,7 +42,8 @@ GetCurrentOrgQuota fetches organization quota
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `orgs.quotas:read` and scope `org:id:1` (orgIDScope).
 */
 func (a *Client) GetCurrentOrgQuota(opts ...ClientOption) (*GetCurrentOrgQuotaOK, error) {
-	return a.GetCurrentOrgQuotaWithParams(nil, opts...)
+	params := NewGetCurrentOrgQuotaParams()
+	return a.GetCurrentOrgQuotaWithParams(params, opts...)
 }
 
 func (a *Client) GetCurrentOrgQuotaWithParams(params *GetCurrentOrgQuotaParams, opts ...ClientOption) (*GetCurrentOrgQuotaOK, error) {

--- a/client/ldap_debug/ldap_debug_client.go
+++ b/client/ldap_debug/ldap_debug_client.go
@@ -42,7 +42,8 @@ GetSyncStatus returns the current state of the LDAP background sync integration
 You need to have a permission with action `ldap.status:read`.
 */
 func (a *Client) GetSyncStatus(opts ...ClientOption) (*GetSyncStatusOK, error) {
-	return a.GetSyncStatusWithParams(nil, opts...)
+	params := NewGetSyncStatusParams()
+	return a.GetSyncStatusWithParams(params, opts...)
 }
 
 func (a *Client) GetSyncStatusWithParams(params *GetSyncStatusParams, opts ...ClientOption) (*GetSyncStatusOK, error) {

--- a/client/legacy_alerts/legacy_alerts_client.go
+++ b/client/legacy_alerts/legacy_alerts_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new legacy alerts API client.
@@ -30,13 +32,16 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetAlertByID(params *GetAlertByIDParams, opts ...ClientOption) (*GetAlertByIDOK, error)
+	GetAlertByID(alertID string, opts ...ClientOption) (*GetAlertByIDOK, error)
+	GetAlertByIDWithParams(params *GetAlertByIDParams, opts ...ClientOption) (*GetAlertByIDOK, error)
 
 	GetAlerts(params *GetAlertsParams, opts ...ClientOption) (*GetAlertsOK, error)
 
-	GetDashboardStates(params *GetDashboardStatesParams, opts ...ClientOption) (*GetDashboardStatesOK, error)
+	GetDashboardStates(dashboardID int64, opts ...ClientOption) (*GetDashboardStatesOK, error)
+	GetDashboardStatesWithParams(params *GetDashboardStatesParams, opts ...ClientOption) (*GetDashboardStatesOK, error)
 
-	PauseAlert(params *PauseAlertParams, opts ...ClientOption) (*PauseAlertOK, error)
+	PauseAlert(alertID string, body *models.PauseAlertCommand, opts ...ClientOption) (*PauseAlertOK, error)
+	PauseAlertWithParams(params *PauseAlertParams, opts ...ClientOption) (*PauseAlertOK, error)
 
 	TestAlert(params *TestAlertParams, opts ...ClientOption) (*TestAlertOK, error)
 
@@ -44,13 +49,17 @@ type ClientService interface {
 }
 
 /*
-	GetAlertByID gets alert by ID
+GetAlertByID gets alert by ID
 
-	“evalMatches” data in the response is cached in the db when and only when the state of the alert changes (e.g. transitioning from “ok” to “alerting” state).
-
+“evalMatches” data in the response is cached in the db when and only when the state of the alert changes (e.g. transitioning from “ok” to “alerting” state).
 If data from one server triggers the alert first and, before that server is seen leaving alerting state, a second server also enters a state that would trigger the alert, the second server will not be visible in “evalMatches” data.
 */
-func (a *Client) GetAlertByID(params *GetAlertByIDParams, opts ...ClientOption) (*GetAlertByIDOK, error) {
+func (a *Client) GetAlertByID(alertID string, opts ...ClientOption) (*GetAlertByIDOK, error) {
+	params := NewGetAlertByIDParams().WithAlertID(alertID)
+	return a.GetAlertByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetAlertByIDWithParams(params *GetAlertByIDParams, opts ...ClientOption) (*GetAlertByIDOK, error) {
 	if params == nil {
 		params = NewGetAlertByIDParams()
 	}
@@ -89,6 +98,7 @@ func (a *Client) GetAlertByID(params *GetAlertByIDParams, opts ...ClientOption) 
 /*
 GetAlerts gets legacy alerts
 */
+
 func (a *Client) GetAlerts(params *GetAlertsParams, opts ...ClientOption) (*GetAlertsOK, error) {
 	if params == nil {
 		params = NewGetAlertsParams()
@@ -128,7 +138,12 @@ func (a *Client) GetAlerts(params *GetAlertsParams, opts ...ClientOption) (*GetA
 /*
 GetDashboardStates gets alert states for a dashboard
 */
-func (a *Client) GetDashboardStates(params *GetDashboardStatesParams, opts ...ClientOption) (*GetDashboardStatesOK, error) {
+func (a *Client) GetDashboardStates(dashboardID int64, opts ...ClientOption) (*GetDashboardStatesOK, error) {
+	params := NewGetDashboardStatesParams().WithDashboardID(dashboardID)
+	return a.GetDashboardStatesWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardStatesWithParams(params *GetDashboardStatesParams, opts ...ClientOption) (*GetDashboardStatesOK, error) {
 	if params == nil {
 		params = NewGetDashboardStatesParams()
 	}
@@ -167,7 +182,12 @@ func (a *Client) GetDashboardStates(params *GetDashboardStatesParams, opts ...Cl
 /*
 PauseAlert pauses unpause alert by id
 */
-func (a *Client) PauseAlert(params *PauseAlertParams, opts ...ClientOption) (*PauseAlertOK, error) {
+func (a *Client) PauseAlert(alertID string, body *models.PauseAlertCommand, opts ...ClientOption) (*PauseAlertOK, error) {
+	params := NewPauseAlertParams().WithAlertID(alertID).WithBody(body)
+	return a.PauseAlertWithParams(params, opts...)
+}
+
+func (a *Client) PauseAlertWithParams(params *PauseAlertParams, opts ...ClientOption) (*PauseAlertOK, error) {
 	if params == nil {
 		params = NewPauseAlertParams()
 	}
@@ -206,6 +226,7 @@ func (a *Client) PauseAlert(params *PauseAlertParams, opts ...ClientOption) (*Pa
 /*
 TestAlert tests alert
 */
+
 func (a *Client) TestAlert(params *TestAlertParams, opts ...ClientOption) (*TestAlertOK, error) {
 	if params == nil {
 		params = NewTestAlertParams()

--- a/client/legacy_alerts_notification_channels/legacy_alerts_notification_channels_client.go
+++ b/client/legacy_alerts_notification_channels/legacy_alerts_notification_channels_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new legacy alerts notification channels API client.
@@ -30,15 +32,20 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateAlertNotificationChannel(params *CreateAlertNotificationChannelParams, opts ...ClientOption) (*CreateAlertNotificationChannelOK, error)
+	CreateAlertNotificationChannel(body *models.CreateAlertNotificationCommand, opts ...ClientOption) (*CreateAlertNotificationChannelOK, error)
+	CreateAlertNotificationChannelWithParams(params *CreateAlertNotificationChannelParams, opts ...ClientOption) (*CreateAlertNotificationChannelOK, error)
 
-	DeleteAlertNotificationChannel(params *DeleteAlertNotificationChannelParams, opts ...ClientOption) (*DeleteAlertNotificationChannelOK, error)
+	DeleteAlertNotificationChannel(notificationChannelID int64, opts ...ClientOption) (*DeleteAlertNotificationChannelOK, error)
+	DeleteAlertNotificationChannelWithParams(params *DeleteAlertNotificationChannelParams, opts ...ClientOption) (*DeleteAlertNotificationChannelOK, error)
 
-	DeleteAlertNotificationChannelByUID(params *DeleteAlertNotificationChannelByUIDParams, opts ...ClientOption) (*DeleteAlertNotificationChannelByUIDOK, error)
+	DeleteAlertNotificationChannelByUID(notificationChannelUID string, opts ...ClientOption) (*DeleteAlertNotificationChannelByUIDOK, error)
+	DeleteAlertNotificationChannelByUIDWithParams(params *DeleteAlertNotificationChannelByUIDParams, opts ...ClientOption) (*DeleteAlertNotificationChannelByUIDOK, error)
 
-	GetAlertNotificationChannelByID(params *GetAlertNotificationChannelByIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByIDOK, error)
+	GetAlertNotificationChannelByID(notificationChannelID int64, opts ...ClientOption) (*GetAlertNotificationChannelByIDOK, error)
+	GetAlertNotificationChannelByIDWithParams(params *GetAlertNotificationChannelByIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByIDOK, error)
 
-	GetAlertNotificationChannelByUID(params *GetAlertNotificationChannelByUIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error)
+	GetAlertNotificationChannelByUID(notificationChannelUID string, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error)
+	GetAlertNotificationChannelByUIDWithParams(params *GetAlertNotificationChannelByUIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error)
 
 	GetAlertNotificationChannels(opts ...ClientOption) (*GetAlertNotificationChannelsOK, error)
 	GetAlertNotificationChannelsWithParams(params *GetAlertNotificationChannelsParams, opts ...ClientOption) (*GetAlertNotificationChannelsOK, error)
@@ -46,11 +53,14 @@ type ClientService interface {
 	GetAlertNotificationLookup(opts ...ClientOption) (*GetAlertNotificationLookupOK, error)
 	GetAlertNotificationLookupWithParams(params *GetAlertNotificationLookupParams, opts ...ClientOption) (*GetAlertNotificationLookupOK, error)
 
-	NotificationChannelTest(params *NotificationChannelTestParams, opts ...ClientOption) (*NotificationChannelTestOK, error)
+	NotificationChannelTest(body *models.NotificationTestCommand, opts ...ClientOption) (*NotificationChannelTestOK, error)
+	NotificationChannelTestWithParams(params *NotificationChannelTestParams, opts ...ClientOption) (*NotificationChannelTestOK, error)
 
-	UpdateAlertNotificationChannel(params *UpdateAlertNotificationChannelParams, opts ...ClientOption) (*UpdateAlertNotificationChannelOK, error)
+	UpdateAlertNotificationChannel(notificationChannelID int64, body *models.UpdateAlertNotificationCommand, opts ...ClientOption) (*UpdateAlertNotificationChannelOK, error)
+	UpdateAlertNotificationChannelWithParams(params *UpdateAlertNotificationChannelParams, opts ...ClientOption) (*UpdateAlertNotificationChannelOK, error)
 
-	UpdateAlertNotificationChannelByUID(params *UpdateAlertNotificationChannelByUIDParams, opts ...ClientOption) (*UpdateAlertNotificationChannelByUIDOK, error)
+	UpdateAlertNotificationChannelByUID(notificationChannelUID string, body *models.UpdateAlertNotificationWithUIDCommand, opts ...ClientOption) (*UpdateAlertNotificationChannelByUIDOK, error)
+	UpdateAlertNotificationChannelByUIDWithParams(params *UpdateAlertNotificationChannelByUIDParams, opts ...ClientOption) (*UpdateAlertNotificationChannelByUIDOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -60,7 +70,12 @@ CreateAlertNotificationChannel creates notification channel
 
 You can find the full list of [supported notifiers](https://grafana.com/docs/grafana/latest/alerting/old-alerting/notifications/#list-of-supported-notifiers) on the alert notifiers page.
 */
-func (a *Client) CreateAlertNotificationChannel(params *CreateAlertNotificationChannelParams, opts ...ClientOption) (*CreateAlertNotificationChannelOK, error) {
+func (a *Client) CreateAlertNotificationChannel(body *models.CreateAlertNotificationCommand, opts ...ClientOption) (*CreateAlertNotificationChannelOK, error) {
+	params := NewCreateAlertNotificationChannelParams().WithBody(body)
+	return a.CreateAlertNotificationChannelWithParams(params, opts...)
+}
+
+func (a *Client) CreateAlertNotificationChannelWithParams(params *CreateAlertNotificationChannelParams, opts ...ClientOption) (*CreateAlertNotificationChannelOK, error) {
 	if params == nil {
 		params = NewCreateAlertNotificationChannelParams()
 	}
@@ -101,7 +116,12 @@ DeleteAlertNotificationChannel deletes alert notification by ID
 
 Deletes an existing notification channel identified by ID.
 */
-func (a *Client) DeleteAlertNotificationChannel(params *DeleteAlertNotificationChannelParams, opts ...ClientOption) (*DeleteAlertNotificationChannelOK, error) {
+func (a *Client) DeleteAlertNotificationChannel(notificationChannelID int64, opts ...ClientOption) (*DeleteAlertNotificationChannelOK, error) {
+	params := NewDeleteAlertNotificationChannelParams().WithNotificationChannelID(notificationChannelID)
+	return a.DeleteAlertNotificationChannelWithParams(params, opts...)
+}
+
+func (a *Client) DeleteAlertNotificationChannelWithParams(params *DeleteAlertNotificationChannelParams, opts ...ClientOption) (*DeleteAlertNotificationChannelOK, error) {
 	if params == nil {
 		params = NewDeleteAlertNotificationChannelParams()
 	}
@@ -142,7 +162,12 @@ DeleteAlertNotificationChannelByUID deletes alert notification by UID
 
 Deletes an existing notification channel identified by UID.
 */
-func (a *Client) DeleteAlertNotificationChannelByUID(params *DeleteAlertNotificationChannelByUIDParams, opts ...ClientOption) (*DeleteAlertNotificationChannelByUIDOK, error) {
+func (a *Client) DeleteAlertNotificationChannelByUID(notificationChannelUID string, opts ...ClientOption) (*DeleteAlertNotificationChannelByUIDOK, error) {
+	params := NewDeleteAlertNotificationChannelByUIDParams().WithNotificationChannelUID(notificationChannelUID)
+	return a.DeleteAlertNotificationChannelByUIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteAlertNotificationChannelByUIDWithParams(params *DeleteAlertNotificationChannelByUIDParams, opts ...ClientOption) (*DeleteAlertNotificationChannelByUIDOK, error) {
 	if params == nil {
 		params = NewDeleteAlertNotificationChannelByUIDParams()
 	}
@@ -183,7 +208,12 @@ GetAlertNotificationChannelByID gets notification channel by ID
 
 Returns the notification channel given the notification channel ID.
 */
-func (a *Client) GetAlertNotificationChannelByID(params *GetAlertNotificationChannelByIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByIDOK, error) {
+func (a *Client) GetAlertNotificationChannelByID(notificationChannelID int64, opts ...ClientOption) (*GetAlertNotificationChannelByIDOK, error) {
+	params := NewGetAlertNotificationChannelByIDParams().WithNotificationChannelID(notificationChannelID)
+	return a.GetAlertNotificationChannelByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetAlertNotificationChannelByIDWithParams(params *GetAlertNotificationChannelByIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByIDOK, error) {
 	if params == nil {
 		params = NewGetAlertNotificationChannelByIDParams()
 	}
@@ -224,7 +254,12 @@ GetAlertNotificationChannelByUID gets notification channel by UID
 
 Returns the notification channel given the notification channel UID.
 */
-func (a *Client) GetAlertNotificationChannelByUID(params *GetAlertNotificationChannelByUIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error) {
+func (a *Client) GetAlertNotificationChannelByUID(notificationChannelUID string, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error) {
+	params := NewGetAlertNotificationChannelByUIDParams().WithNotificationChannelUID(notificationChannelUID)
+	return a.GetAlertNotificationChannelByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetAlertNotificationChannelByUIDWithParams(params *GetAlertNotificationChannelByUIDParams, opts ...ClientOption) (*GetAlertNotificationChannelByUIDOK, error) {
 	if params == nil {
 		params = NewGetAlertNotificationChannelByUIDParams()
 	}
@@ -266,7 +301,8 @@ GetAlertNotificationChannels gets all notification channels
 Returns all notification channels that the authenticated user has permission to view.
 */
 func (a *Client) GetAlertNotificationChannels(opts ...ClientOption) (*GetAlertNotificationChannelsOK, error) {
-	return a.GetAlertNotificationChannelsWithParams(nil, opts...)
+	params := NewGetAlertNotificationChannelsParams()
+	return a.GetAlertNotificationChannelsWithParams(params, opts...)
 }
 
 func (a *Client) GetAlertNotificationChannelsWithParams(params *GetAlertNotificationChannelsParams, opts ...ClientOption) (*GetAlertNotificationChannelsOK, error) {
@@ -311,7 +347,8 @@ GetAlertNotificationLookup gets all notification channels lookup
 Returns all notification channels, but with less detailed information. Accessible by any authenticated user and is mainly used by providing alert notification channels in Grafana UI when configuring alert rule.
 */
 func (a *Client) GetAlertNotificationLookup(opts ...ClientOption) (*GetAlertNotificationLookupOK, error) {
-	return a.GetAlertNotificationLookupWithParams(nil, opts...)
+	params := NewGetAlertNotificationLookupParams()
+	return a.GetAlertNotificationLookupWithParams(params, opts...)
 }
 
 func (a *Client) GetAlertNotificationLookupWithParams(params *GetAlertNotificationLookupParams, opts ...ClientOption) (*GetAlertNotificationLookupOK, error) {
@@ -355,7 +392,12 @@ NotificationChannelTest tests notification channel
 
 Sends a test notification to the channel.
 */
-func (a *Client) NotificationChannelTest(params *NotificationChannelTestParams, opts ...ClientOption) (*NotificationChannelTestOK, error) {
+func (a *Client) NotificationChannelTest(body *models.NotificationTestCommand, opts ...ClientOption) (*NotificationChannelTestOK, error) {
+	params := NewNotificationChannelTestParams().WithBody(body)
+	return a.NotificationChannelTestWithParams(params, opts...)
+}
+
+func (a *Client) NotificationChannelTestWithParams(params *NotificationChannelTestParams, opts ...ClientOption) (*NotificationChannelTestOK, error) {
 	if params == nil {
 		params = NewNotificationChannelTestParams()
 	}
@@ -396,7 +438,12 @@ UpdateAlertNotificationChannel updates notification channel by ID
 
 Updates an existing notification channel identified by ID.
 */
-func (a *Client) UpdateAlertNotificationChannel(params *UpdateAlertNotificationChannelParams, opts ...ClientOption) (*UpdateAlertNotificationChannelOK, error) {
+func (a *Client) UpdateAlertNotificationChannel(notificationChannelID int64, body *models.UpdateAlertNotificationCommand, opts ...ClientOption) (*UpdateAlertNotificationChannelOK, error) {
+	params := NewUpdateAlertNotificationChannelParams().WithBody(body).WithNotificationChannelID(notificationChannelID)
+	return a.UpdateAlertNotificationChannelWithParams(params, opts...)
+}
+
+func (a *Client) UpdateAlertNotificationChannelWithParams(params *UpdateAlertNotificationChannelParams, opts ...ClientOption) (*UpdateAlertNotificationChannelOK, error) {
 	if params == nil {
 		params = NewUpdateAlertNotificationChannelParams()
 	}
@@ -437,7 +484,12 @@ UpdateAlertNotificationChannelByUID updates notification channel by UID
 
 Updates an existing notification channel identified by uid.
 */
-func (a *Client) UpdateAlertNotificationChannelByUID(params *UpdateAlertNotificationChannelByUIDParams, opts ...ClientOption) (*UpdateAlertNotificationChannelByUIDOK, error) {
+func (a *Client) UpdateAlertNotificationChannelByUID(notificationChannelUID string, body *models.UpdateAlertNotificationWithUIDCommand, opts ...ClientOption) (*UpdateAlertNotificationChannelByUIDOK, error) {
+	params := NewUpdateAlertNotificationChannelByUIDParams().WithBody(body).WithNotificationChannelUID(notificationChannelUID)
+	return a.UpdateAlertNotificationChannelByUIDWithParams(params, opts...)
+}
+
+func (a *Client) UpdateAlertNotificationChannelByUIDWithParams(params *UpdateAlertNotificationChannelByUIDParams, opts ...ClientOption) (*UpdateAlertNotificationChannelByUIDOK, error) {
 	if params == nil {
 		params = NewUpdateAlertNotificationChannelByUIDParams()
 	}

--- a/client/library_elements/library_elements_client.go
+++ b/client/library_elements/library_elements_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new library elements API client.
@@ -30,19 +32,25 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateLibraryElement(params *CreateLibraryElementParams, opts ...ClientOption) (*CreateLibraryElementOK, error)
+	CreateLibraryElement(body *models.CreateLibraryElementCommand, opts ...ClientOption) (*CreateLibraryElementOK, error)
+	CreateLibraryElementWithParams(params *CreateLibraryElementParams, opts ...ClientOption) (*CreateLibraryElementOK, error)
 
-	DeleteLibraryElementByUID(params *DeleteLibraryElementByUIDParams, opts ...ClientOption) (*DeleteLibraryElementByUIDOK, error)
+	DeleteLibraryElementByUID(libraryElementUID string, opts ...ClientOption) (*DeleteLibraryElementByUIDOK, error)
+	DeleteLibraryElementByUIDWithParams(params *DeleteLibraryElementByUIDParams, opts ...ClientOption) (*DeleteLibraryElementByUIDOK, error)
 
-	GetLibraryElementByName(params *GetLibraryElementByNameParams, opts ...ClientOption) (*GetLibraryElementByNameOK, error)
+	GetLibraryElementByName(libraryElementName string, opts ...ClientOption) (*GetLibraryElementByNameOK, error)
+	GetLibraryElementByNameWithParams(params *GetLibraryElementByNameParams, opts ...ClientOption) (*GetLibraryElementByNameOK, error)
 
-	GetLibraryElementByUID(params *GetLibraryElementByUIDParams, opts ...ClientOption) (*GetLibraryElementByUIDOK, error)
+	GetLibraryElementByUID(libraryElementUID string, opts ...ClientOption) (*GetLibraryElementByUIDOK, error)
+	GetLibraryElementByUIDWithParams(params *GetLibraryElementByUIDParams, opts ...ClientOption) (*GetLibraryElementByUIDOK, error)
 
-	GetLibraryElementConnections(params *GetLibraryElementConnectionsParams, opts ...ClientOption) (*GetLibraryElementConnectionsOK, error)
+	GetLibraryElementConnections(libraryElementUID string, opts ...ClientOption) (*GetLibraryElementConnectionsOK, error)
+	GetLibraryElementConnectionsWithParams(params *GetLibraryElementConnectionsParams, opts ...ClientOption) (*GetLibraryElementConnectionsOK, error)
 
 	GetLibraryElements(params *GetLibraryElementsParams, opts ...ClientOption) (*GetLibraryElementsOK, error)
 
-	UpdateLibraryElement(params *UpdateLibraryElementParams, opts ...ClientOption) (*UpdateLibraryElementOK, error)
+	UpdateLibraryElement(libraryElementUID string, body *models.PatchLibraryElementCommand, opts ...ClientOption) (*UpdateLibraryElementOK, error)
+	UpdateLibraryElementWithParams(params *UpdateLibraryElementParams, opts ...ClientOption) (*UpdateLibraryElementOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -52,7 +60,12 @@ CreateLibraryElement creates library element
 
 Creates a new library element.
 */
-func (a *Client) CreateLibraryElement(params *CreateLibraryElementParams, opts ...ClientOption) (*CreateLibraryElementOK, error) {
+func (a *Client) CreateLibraryElement(body *models.CreateLibraryElementCommand, opts ...ClientOption) (*CreateLibraryElementOK, error) {
+	params := NewCreateLibraryElementParams().WithBody(body)
+	return a.CreateLibraryElementWithParams(params, opts...)
+}
+
+func (a *Client) CreateLibraryElementWithParams(params *CreateLibraryElementParams, opts ...ClientOption) (*CreateLibraryElementOK, error) {
 	if params == nil {
 		params = NewCreateLibraryElementParams()
 	}
@@ -89,13 +102,17 @@ func (a *Client) CreateLibraryElement(params *CreateLibraryElementParams, opts .
 }
 
 /*
-	DeleteLibraryElementByUID deletes library element
+DeleteLibraryElementByUID deletes library element
 
-	Deletes an existing library element as specified by the UID. This operation cannot be reverted.
-
+Deletes an existing library element as specified by the UID. This operation cannot be reverted.
 You cannot delete a library element that is connected. This operation cannot be reverted.
 */
-func (a *Client) DeleteLibraryElementByUID(params *DeleteLibraryElementByUIDParams, opts ...ClientOption) (*DeleteLibraryElementByUIDOK, error) {
+func (a *Client) DeleteLibraryElementByUID(libraryElementUID string, opts ...ClientOption) (*DeleteLibraryElementByUIDOK, error) {
+	params := NewDeleteLibraryElementByUIDParams().WithLibraryElementUID(libraryElementUID)
+	return a.DeleteLibraryElementByUIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteLibraryElementByUIDWithParams(params *DeleteLibraryElementByUIDParams, opts ...ClientOption) (*DeleteLibraryElementByUIDOK, error) {
 	if params == nil {
 		params = NewDeleteLibraryElementByUIDParams()
 	}
@@ -136,7 +153,12 @@ GetLibraryElementByName gets library element by name
 
 Returns a library element with the given name.
 */
-func (a *Client) GetLibraryElementByName(params *GetLibraryElementByNameParams, opts ...ClientOption) (*GetLibraryElementByNameOK, error) {
+func (a *Client) GetLibraryElementByName(libraryElementName string, opts ...ClientOption) (*GetLibraryElementByNameOK, error) {
+	params := NewGetLibraryElementByNameParams().WithLibraryElementName(libraryElementName)
+	return a.GetLibraryElementByNameWithParams(params, opts...)
+}
+
+func (a *Client) GetLibraryElementByNameWithParams(params *GetLibraryElementByNameParams, opts ...ClientOption) (*GetLibraryElementByNameOK, error) {
 	if params == nil {
 		params = NewGetLibraryElementByNameParams()
 	}
@@ -177,7 +199,12 @@ GetLibraryElementByUID gets library element by UID
 
 Returns a library element with the given UID.
 */
-func (a *Client) GetLibraryElementByUID(params *GetLibraryElementByUIDParams, opts ...ClientOption) (*GetLibraryElementByUIDOK, error) {
+func (a *Client) GetLibraryElementByUID(libraryElementUID string, opts ...ClientOption) (*GetLibraryElementByUIDOK, error) {
+	params := NewGetLibraryElementByUIDParams().WithLibraryElementUID(libraryElementUID)
+	return a.GetLibraryElementByUIDWithParams(params, opts...)
+}
+
+func (a *Client) GetLibraryElementByUIDWithParams(params *GetLibraryElementByUIDParams, opts ...ClientOption) (*GetLibraryElementByUIDOK, error) {
 	if params == nil {
 		params = NewGetLibraryElementByUIDParams()
 	}
@@ -218,7 +245,12 @@ GetLibraryElementConnections gets library element connections
 
 Returns a list of connections for a library element based on the UID specified.
 */
-func (a *Client) GetLibraryElementConnections(params *GetLibraryElementConnectionsParams, opts ...ClientOption) (*GetLibraryElementConnectionsOK, error) {
+func (a *Client) GetLibraryElementConnections(libraryElementUID string, opts ...ClientOption) (*GetLibraryElementConnectionsOK, error) {
+	params := NewGetLibraryElementConnectionsParams().WithLibraryElementUID(libraryElementUID)
+	return a.GetLibraryElementConnectionsWithParams(params, opts...)
+}
+
+func (a *Client) GetLibraryElementConnectionsWithParams(params *GetLibraryElementConnectionsParams, opts ...ClientOption) (*GetLibraryElementConnectionsOK, error) {
 	if params == nil {
 		params = NewGetLibraryElementConnectionsParams()
 	}
@@ -255,13 +287,13 @@ func (a *Client) GetLibraryElementConnections(params *GetLibraryElementConnectio
 }
 
 /*
-	GetLibraryElements gets all library elements
+GetLibraryElements gets all library elements
 
-	Returns a list of all library elements the authenticated user has permission to view.
-
+Returns a list of all library elements the authenticated user has permission to view.
 Use the `perPage` query parameter to control the maximum number of library elements returned; the default limit is `100`.
 You can also use the `page` query parameter to fetch library elements from any page other than the first one.
 */
+
 func (a *Client) GetLibraryElements(params *GetLibraryElementsParams, opts ...ClientOption) (*GetLibraryElementsOK, error) {
 	if params == nil {
 		params = NewGetLibraryElementsParams()
@@ -303,7 +335,12 @@ UpdateLibraryElement updates library element
 
 Updates an existing library element identified by uid.
 */
-func (a *Client) UpdateLibraryElement(params *UpdateLibraryElementParams, opts ...ClientOption) (*UpdateLibraryElementOK, error) {
+func (a *Client) UpdateLibraryElement(libraryElementUID string, body *models.PatchLibraryElementCommand, opts ...ClientOption) (*UpdateLibraryElementOK, error) {
+	params := NewUpdateLibraryElementParams().WithBody(body).WithLibraryElementUID(libraryElementUID)
+	return a.UpdateLibraryElementWithParams(params, opts...)
+}
+
+func (a *Client) UpdateLibraryElementWithParams(params *UpdateLibraryElementParams, opts ...ClientOption) (*UpdateLibraryElementOK, error) {
 	if params == nil {
 		params = NewUpdateLibraryElementParams()
 	}

--- a/client/licensing/licensing_client.go
+++ b/client/licensing/licensing_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new licensing API client.
@@ -30,7 +32,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteLicenseToken(params *DeleteLicenseTokenParams, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error)
+	DeleteLicenseToken(body *models.DeleteTokenCommand, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error)
+	DeleteLicenseTokenWithParams(params *DeleteLicenseTokenParams, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error)
 
 	GetCustomPermissionsCSV(opts ...ClientOption) (*GetCustomPermissionsCSVOK, error)
 	GetCustomPermissionsCSVWithParams(params *GetCustomPermissionsCSVParams, opts ...ClientOption) (*GetCustomPermissionsCSVOK, error)
@@ -44,9 +47,11 @@ type ClientService interface {
 	GetStatus(opts ...ClientOption) (*GetStatusOK, error)
 	GetStatusWithParams(params *GetStatusParams, opts ...ClientOption) (*GetStatusOK, error)
 
-	PostLicenseToken(params *PostLicenseTokenParams, opts ...ClientOption) (*PostLicenseTokenOK, error)
+	PostLicenseToken(body *models.DeleteTokenCommand, opts ...ClientOption) (*PostLicenseTokenOK, error)
+	PostLicenseTokenWithParams(params *PostLicenseTokenParams, opts ...ClientOption) (*PostLicenseTokenOK, error)
 
-	PostRenewLicenseToken(params *PostRenewLicenseTokenParams, opts ...ClientOption) (*PostRenewLicenseTokenOK, error)
+	PostRenewLicenseToken(body interface{}, opts ...ClientOption) (*PostRenewLicenseTokenOK, error)
+	PostRenewLicenseTokenWithParams(params *PostRenewLicenseTokenParams, opts ...ClientOption) (*PostRenewLicenseTokenOK, error)
 
 	RefreshLicenseStats(opts ...ClientOption) (*RefreshLicenseStatsOK, error)
 	RefreshLicenseStatsWithParams(params *RefreshLicenseStatsParams, opts ...ClientOption) (*RefreshLicenseStatsOK, error)
@@ -55,13 +60,18 @@ type ClientService interface {
 }
 
 /*
-	DeleteLicenseToken removes license from database
+DeleteLicenseToken removes license from database
 
-	Removes the license stored in the Grafana database. Available in Grafana Enterprise v7.4+.
+Removes the license stored in the Grafana database. Available in Grafana Enterprise v7.4+.
 
 You need to have a permission with action `licensing:delete`.
 */
-func (a *Client) DeleteLicenseToken(params *DeleteLicenseTokenParams, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error) {
+func (a *Client) DeleteLicenseToken(body *models.DeleteTokenCommand, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error) {
+	params := NewDeleteLicenseTokenParams().WithBody(body)
+	return a.DeleteLicenseTokenWithParams(params, opts...)
+}
+
+func (a *Client) DeleteLicenseTokenWithParams(params *DeleteLicenseTokenParams, opts ...ClientOption) (*DeleteLicenseTokenAccepted, error) {
 	if params == nil {
 		params = NewDeleteLicenseTokenParams()
 	}
@@ -103,7 +113,8 @@ GetCustomPermissionsCSV gets custom permissions report in CSV format
 You need to have a permission with action `licensing.reports:read`.
 */
 func (a *Client) GetCustomPermissionsCSV(opts ...ClientOption) (*GetCustomPermissionsCSVOK, error) {
-	return a.GetCustomPermissionsCSVWithParams(nil, opts...)
+	params := NewGetCustomPermissionsCSVParams()
+	return a.GetCustomPermissionsCSVWithParams(params, opts...)
 }
 
 func (a *Client) GetCustomPermissionsCSVWithParams(params *GetCustomPermissionsCSVParams, opts ...ClientOption) (*GetCustomPermissionsCSVOK, error) {
@@ -148,7 +159,8 @@ GetCustomPermissionsReport gets custom permissions report
 You need to have a permission with action `licensing.reports:read`.
 */
 func (a *Client) GetCustomPermissionsReport(opts ...ClientOption) (*GetCustomPermissionsReportOK, error) {
-	return a.GetCustomPermissionsReportWithParams(nil, opts...)
+	params := NewGetCustomPermissionsReportParams()
+	return a.GetCustomPermissionsReportWithParams(params, opts...)
 }
 
 func (a *Client) GetCustomPermissionsReportWithParams(params *GetCustomPermissionsReportParams, opts ...ClientOption) (*GetCustomPermissionsReportOK, error) {
@@ -193,7 +205,8 @@ GetLicenseToken gets license token
 You need to have a permission with action `licensing:read`.
 */
 func (a *Client) GetLicenseToken(opts ...ClientOption) (*GetLicenseTokenOK, error) {
-	return a.GetLicenseTokenWithParams(nil, opts...)
+	params := NewGetLicenseTokenParams()
+	return a.GetLicenseTokenWithParams(params, opts...)
 }
 
 func (a *Client) GetLicenseTokenWithParams(params *GetLicenseTokenParams, opts ...ClientOption) (*GetLicenseTokenOK, error) {
@@ -236,7 +249,8 @@ func (a *Client) GetLicenseTokenWithParams(params *GetLicenseTokenParams, opts .
 GetStatus checks license availability
 */
 func (a *Client) GetStatus(opts ...ClientOption) (*GetStatusOK, error) {
-	return a.GetStatusWithParams(nil, opts...)
+	params := NewGetStatusParams()
+	return a.GetStatusWithParams(params, opts...)
 }
 
 func (a *Client) GetStatusWithParams(params *GetStatusParams, opts ...ClientOption) (*GetStatusOK, error) {
@@ -280,7 +294,12 @@ PostLicenseToken creates license token
 
 You need to have a permission with action `licensing:update`.
 */
-func (a *Client) PostLicenseToken(params *PostLicenseTokenParams, opts ...ClientOption) (*PostLicenseTokenOK, error) {
+func (a *Client) PostLicenseToken(body *models.DeleteTokenCommand, opts ...ClientOption) (*PostLicenseTokenOK, error) {
+	params := NewPostLicenseTokenParams().WithBody(body)
+	return a.PostLicenseTokenWithParams(params, opts...)
+}
+
+func (a *Client) PostLicenseTokenWithParams(params *PostLicenseTokenParams, opts ...ClientOption) (*PostLicenseTokenOK, error) {
 	if params == nil {
 		params = NewPostLicenseTokenParams()
 	}
@@ -317,13 +336,18 @@ func (a *Client) PostLicenseToken(params *PostLicenseTokenParams, opts ...Client
 }
 
 /*
-	PostRenewLicenseToken manuallies force license refresh
+PostRenewLicenseToken manuallies force license refresh
 
-	Manually ask license issuer for a new token. Available in Grafana Enterprise v7.4+.
+Manually ask license issuer for a new token. Available in Grafana Enterprise v7.4+.
 
 You need to have a permission with action `licensing:update`.
 */
-func (a *Client) PostRenewLicenseToken(params *PostRenewLicenseTokenParams, opts ...ClientOption) (*PostRenewLicenseTokenOK, error) {
+func (a *Client) PostRenewLicenseToken(body interface{}, opts ...ClientOption) (*PostRenewLicenseTokenOK, error) {
+	params := NewPostRenewLicenseTokenParams().WithBody(body)
+	return a.PostRenewLicenseTokenWithParams(params, opts...)
+}
+
+func (a *Client) PostRenewLicenseTokenWithParams(params *PostRenewLicenseTokenParams, opts ...ClientOption) (*PostRenewLicenseTokenOK, error) {
 	if params == nil {
 		params = NewPostRenewLicenseTokenParams()
 	}
@@ -365,7 +389,8 @@ RefreshLicenseStats refreshes license stats
 You need to have a permission with action `licensing:read`.
 */
 func (a *Client) RefreshLicenseStats(opts ...ClientOption) (*RefreshLicenseStatsOK, error) {
-	return a.RefreshLicenseStatsWithParams(nil, opts...)
+	params := NewRefreshLicenseStatsParams()
+	return a.RefreshLicenseStatsWithParams(params, opts...)
 }
 
 func (a *Client) RefreshLicenseStatsWithParams(params *RefreshLicenseStatsParams, opts ...ClientOption) (*RefreshLicenseStatsOK, error) {

--- a/client/org/org_client.go
+++ b/client/org/org_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new org API client.
@@ -30,7 +32,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddOrgUserToCurrentOrg(params *AddOrgUserToCurrentOrgParams, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error)
+	AddOrgUserToCurrentOrg(body *models.AddOrgUserCommand, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error)
+	AddOrgUserToCurrentOrgWithParams(params *AddOrgUserToCurrentOrgParams, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error)
 
 	GetCurrentOrg(opts ...ClientOption) (*GetCurrentOrgOK, error)
 	GetCurrentOrgWithParams(params *GetCurrentOrgParams, opts ...ClientOption) (*GetCurrentOrgOK, error)
@@ -40,26 +43,35 @@ type ClientService interface {
 
 	GetOrgUsersForCurrentOrgLookup(params *GetOrgUsersForCurrentOrgLookupParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgLookupOK, error)
 
-	RemoveOrgUserForCurrentOrg(params *RemoveOrgUserForCurrentOrgParams, opts ...ClientOption) (*RemoveOrgUserForCurrentOrgOK, error)
+	RemoveOrgUserForCurrentOrg(userID int64, opts ...ClientOption) (*RemoveOrgUserForCurrentOrgOK, error)
+	RemoveOrgUserForCurrentOrgWithParams(params *RemoveOrgUserForCurrentOrgParams, opts ...ClientOption) (*RemoveOrgUserForCurrentOrgOK, error)
 
-	UpdateCurrentOrg(params *UpdateCurrentOrgParams, opts ...ClientOption) (*UpdateCurrentOrgOK, error)
+	UpdateCurrentOrg(body *models.UpdateOrgForm, opts ...ClientOption) (*UpdateCurrentOrgOK, error)
+	UpdateCurrentOrgWithParams(params *UpdateCurrentOrgParams, opts ...ClientOption) (*UpdateCurrentOrgOK, error)
 
-	UpdateCurrentOrgAddress(params *UpdateCurrentOrgAddressParams, opts ...ClientOption) (*UpdateCurrentOrgAddressOK, error)
+	UpdateCurrentOrgAddress(body *models.UpdateOrgAddressForm, opts ...ClientOption) (*UpdateCurrentOrgAddressOK, error)
+	UpdateCurrentOrgAddressWithParams(params *UpdateCurrentOrgAddressParams, opts ...ClientOption) (*UpdateCurrentOrgAddressOK, error)
 
-	UpdateOrgUserForCurrentOrg(params *UpdateOrgUserForCurrentOrgParams, opts ...ClientOption) (*UpdateOrgUserForCurrentOrgOK, error)
+	UpdateOrgUserForCurrentOrg(userID int64, body *models.UpdateOrgUserCommand, opts ...ClientOption) (*UpdateOrgUserForCurrentOrgOK, error)
+	UpdateOrgUserForCurrentOrgWithParams(params *UpdateOrgUserForCurrentOrgParams, opts ...ClientOption) (*UpdateOrgUserForCurrentOrgOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
 
 /*
-	AddOrgUserToCurrentOrg adds a new user to the current organization
+AddOrgUserToCurrentOrg adds a new user to the current organization
 
-	Adds a global user to the current organization.
+Adds a global user to the current organization.
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:add` with scope `users:*`.
 */
-func (a *Client) AddOrgUserToCurrentOrg(params *AddOrgUserToCurrentOrgParams, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error) {
+func (a *Client) AddOrgUserToCurrentOrg(body *models.AddOrgUserCommand, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error) {
+	params := NewAddOrgUserToCurrentOrgParams().WithBody(body)
+	return a.AddOrgUserToCurrentOrgWithParams(params, opts...)
+}
+
+func (a *Client) AddOrgUserToCurrentOrgWithParams(params *AddOrgUserToCurrentOrgParams, opts ...ClientOption) (*AddOrgUserToCurrentOrgOK, error) {
 	if params == nil {
 		params = NewAddOrgUserToCurrentOrgParams()
 	}
@@ -99,7 +111,8 @@ func (a *Client) AddOrgUserToCurrentOrg(params *AddOrgUserToCurrentOrgParams, op
 GetCurrentOrg gets current organization
 */
 func (a *Client) GetCurrentOrg(opts ...ClientOption) (*GetCurrentOrgOK, error) {
-	return a.GetCurrentOrgWithParams(nil, opts...)
+	params := NewGetCurrentOrgParams()
+	return a.GetCurrentOrgWithParams(params, opts...)
 }
 
 func (a *Client) GetCurrentOrgWithParams(params *GetCurrentOrgParams, opts ...ClientOption) (*GetCurrentOrgOK, error) {
@@ -139,15 +152,15 @@ func (a *Client) GetCurrentOrgWithParams(params *GetCurrentOrgParams, opts ...Cl
 }
 
 /*
-	GetOrgUsersForCurrentOrg gets all users within the current organization
+GetOrgUsersForCurrentOrg gets all users within the current organization
 
-	Returns all org users within the current organization. Accessible to users with org admin role.
-
+Returns all org users within the current organization. Accessible to users with org admin role.
 If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:read` with scope `users:*`.
 */
 func (a *Client) GetOrgUsersForCurrentOrg(opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error) {
-	return a.GetOrgUsersForCurrentOrgWithParams(nil, opts...)
+	params := NewGetOrgUsersForCurrentOrgParams()
+	return a.GetOrgUsersForCurrentOrgWithParams(params, opts...)
 }
 
 func (a *Client) GetOrgUsersForCurrentOrgWithParams(params *GetOrgUsersForCurrentOrgParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgOK, error) {
@@ -187,13 +200,13 @@ func (a *Client) GetOrgUsersForCurrentOrgWithParams(params *GetOrgUsersForCurren
 }
 
 /*
-	GetOrgUsersForCurrentOrgLookup gets all users within the current organization lookup
+GetOrgUsersForCurrentOrgLookup gets all users within the current organization lookup
 
-	Returns all org users within the current organization, but with less detailed information.
-
+Returns all org users within the current organization, but with less detailed information.
 Accessible to users with org admin role, admin in any folder or admin of any team.
 Mainly used by Grafana UI for providing list of users when adding team members and when editing folder/dashboard permissions.
 */
+
 func (a *Client) GetOrgUsersForCurrentOrgLookup(params *GetOrgUsersForCurrentOrgLookupParams, opts ...ClientOption) (*GetOrgUsersForCurrentOrgLookupOK, error) {
 	if params == nil {
 		params = NewGetOrgUsersForCurrentOrgLookupParams()
@@ -231,13 +244,17 @@ func (a *Client) GetOrgUsersForCurrentOrgLookup(params *GetOrgUsersForCurrentOrg
 }
 
 /*
-	RemoveOrgUserForCurrentOrg deletes user in current organization
+RemoveOrgUserForCurrentOrg deletes user in current organization
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:remove` with scope `users:*`.
 */
-func (a *Client) RemoveOrgUserForCurrentOrg(params *RemoveOrgUserForCurrentOrgParams, opts ...ClientOption) (*RemoveOrgUserForCurrentOrgOK, error) {
+func (a *Client) RemoveOrgUserForCurrentOrg(userID int64, opts ...ClientOption) (*RemoveOrgUserForCurrentOrgOK, error) {
+	params := NewRemoveOrgUserForCurrentOrgParams().WithUserID(userID)
+	return a.RemoveOrgUserForCurrentOrgWithParams(params, opts...)
+}
+
+func (a *Client) RemoveOrgUserForCurrentOrgWithParams(params *RemoveOrgUserForCurrentOrgParams, opts ...ClientOption) (*RemoveOrgUserForCurrentOrgOK, error) {
 	if params == nil {
 		params = NewRemoveOrgUserForCurrentOrgParams()
 	}
@@ -276,7 +293,12 @@ func (a *Client) RemoveOrgUserForCurrentOrg(params *RemoveOrgUserForCurrentOrgPa
 /*
 UpdateCurrentOrg updates current organization
 */
-func (a *Client) UpdateCurrentOrg(params *UpdateCurrentOrgParams, opts ...ClientOption) (*UpdateCurrentOrgOK, error) {
+func (a *Client) UpdateCurrentOrg(body *models.UpdateOrgForm, opts ...ClientOption) (*UpdateCurrentOrgOK, error) {
+	params := NewUpdateCurrentOrgParams().WithBody(body)
+	return a.UpdateCurrentOrgWithParams(params, opts...)
+}
+
+func (a *Client) UpdateCurrentOrgWithParams(params *UpdateCurrentOrgParams, opts ...ClientOption) (*UpdateCurrentOrgOK, error) {
 	if params == nil {
 		params = NewUpdateCurrentOrgParams()
 	}
@@ -315,7 +337,12 @@ func (a *Client) UpdateCurrentOrg(params *UpdateCurrentOrgParams, opts ...Client
 /*
 UpdateCurrentOrgAddress updates current organization s address
 */
-func (a *Client) UpdateCurrentOrgAddress(params *UpdateCurrentOrgAddressParams, opts ...ClientOption) (*UpdateCurrentOrgAddressOK, error) {
+func (a *Client) UpdateCurrentOrgAddress(body *models.UpdateOrgAddressForm, opts ...ClientOption) (*UpdateCurrentOrgAddressOK, error) {
+	params := NewUpdateCurrentOrgAddressParams().WithBody(body)
+	return a.UpdateCurrentOrgAddressWithParams(params, opts...)
+}
+
+func (a *Client) UpdateCurrentOrgAddressWithParams(params *UpdateCurrentOrgAddressParams, opts ...ClientOption) (*UpdateCurrentOrgAddressOK, error) {
 	if params == nil {
 		params = NewUpdateCurrentOrgAddressParams()
 	}
@@ -352,13 +379,17 @@ func (a *Client) UpdateCurrentOrgAddress(params *UpdateCurrentOrgAddressParams, 
 }
 
 /*
-	UpdateOrgUserForCurrentOrg updates the given user
+UpdateOrgUserForCurrentOrg updates the given user
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users.role:update` with scope `users:*`.
 */
-func (a *Client) UpdateOrgUserForCurrentOrg(params *UpdateOrgUserForCurrentOrgParams, opts ...ClientOption) (*UpdateOrgUserForCurrentOrgOK, error) {
+func (a *Client) UpdateOrgUserForCurrentOrg(userID int64, body *models.UpdateOrgUserCommand, opts ...ClientOption) (*UpdateOrgUserForCurrentOrgOK, error) {
+	params := NewUpdateOrgUserForCurrentOrgParams().WithBody(body).WithUserID(userID)
+	return a.UpdateOrgUserForCurrentOrgWithParams(params, opts...)
+}
+
+func (a *Client) UpdateOrgUserForCurrentOrgWithParams(params *UpdateOrgUserForCurrentOrgParams, opts ...ClientOption) (*UpdateOrgUserForCurrentOrgOK, error) {
 	if params == nil {
 		params = NewUpdateOrgUserForCurrentOrgParams()
 	}

--- a/client/org_invites/org_invites_client.go
+++ b/client/org_invites/org_invites_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new org invites API client.
@@ -30,12 +32,14 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddOrgInvite(params *AddOrgInviteParams, opts ...ClientOption) (*AddOrgInviteOK, error)
+	AddOrgInvite(body *models.AddInviteForm, opts ...ClientOption) (*AddOrgInviteOK, error)
+	AddOrgInviteWithParams(params *AddOrgInviteParams, opts ...ClientOption) (*AddOrgInviteOK, error)
 
 	GetPendingOrgInvites(opts ...ClientOption) (*GetPendingOrgInvitesOK, error)
 	GetPendingOrgInvitesWithParams(params *GetPendingOrgInvitesParams, opts ...ClientOption) (*GetPendingOrgInvitesOK, error)
 
-	RevokeInvite(params *RevokeInviteParams, opts ...ClientOption) (*RevokeInviteOK, error)
+	RevokeInvite(invitationCode string, opts ...ClientOption) (*RevokeInviteOK, error)
+	RevokeInviteWithParams(params *RevokeInviteParams, opts ...ClientOption) (*RevokeInviteOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -43,7 +47,12 @@ type ClientService interface {
 /*
 AddOrgInvite adds invite
 */
-func (a *Client) AddOrgInvite(params *AddOrgInviteParams, opts ...ClientOption) (*AddOrgInviteOK, error) {
+func (a *Client) AddOrgInvite(body *models.AddInviteForm, opts ...ClientOption) (*AddOrgInviteOK, error) {
+	params := NewAddOrgInviteParams().WithBody(body)
+	return a.AddOrgInviteWithParams(params, opts...)
+}
+
+func (a *Client) AddOrgInviteWithParams(params *AddOrgInviteParams, opts ...ClientOption) (*AddOrgInviteOK, error) {
 	if params == nil {
 		params = NewAddOrgInviteParams()
 	}
@@ -83,7 +92,8 @@ func (a *Client) AddOrgInvite(params *AddOrgInviteParams, opts ...ClientOption) 
 GetPendingOrgInvites gets pending invites
 */
 func (a *Client) GetPendingOrgInvites(opts ...ClientOption) (*GetPendingOrgInvitesOK, error) {
-	return a.GetPendingOrgInvitesWithParams(nil, opts...)
+	params := NewGetPendingOrgInvitesParams()
+	return a.GetPendingOrgInvitesWithParams(params, opts...)
 }
 
 func (a *Client) GetPendingOrgInvitesWithParams(params *GetPendingOrgInvitesParams, opts ...ClientOption) (*GetPendingOrgInvitesOK, error) {
@@ -125,7 +135,12 @@ func (a *Client) GetPendingOrgInvitesWithParams(params *GetPendingOrgInvitesPara
 /*
 RevokeInvite revokes invite
 */
-func (a *Client) RevokeInvite(params *RevokeInviteParams, opts ...ClientOption) (*RevokeInviteOK, error) {
+func (a *Client) RevokeInvite(invitationCode string, opts ...ClientOption) (*RevokeInviteOK, error) {
+	params := NewRevokeInviteParams().WithInvitationCode(invitationCode)
+	return a.RevokeInviteWithParams(params, opts...)
+}
+
+func (a *Client) RevokeInviteWithParams(params *RevokeInviteParams, opts ...ClientOption) (*RevokeInviteOK, error) {
 	if params == nil {
 		params = NewRevokeInviteParams()
 	}

--- a/client/org_preferences/org_preferences_client.go
+++ b/client/org_preferences/org_preferences_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new org preferences API client.
@@ -33,9 +35,11 @@ type ClientService interface {
 	GetOrgPreferences(opts ...ClientOption) (*GetOrgPreferencesOK, error)
 	GetOrgPreferencesWithParams(params *GetOrgPreferencesParams, opts ...ClientOption) (*GetOrgPreferencesOK, error)
 
-	PatchOrgPreferences(params *PatchOrgPreferencesParams, opts ...ClientOption) (*PatchOrgPreferencesOK, error)
+	PatchOrgPreferences(body *models.PatchPrefsCmd, opts ...ClientOption) (*PatchOrgPreferencesOK, error)
+	PatchOrgPreferencesWithParams(params *PatchOrgPreferencesParams, opts ...ClientOption) (*PatchOrgPreferencesOK, error)
 
-	UpdateOrgPreferences(params *UpdateOrgPreferencesParams, opts ...ClientOption) (*UpdateOrgPreferencesOK, error)
+	UpdateOrgPreferences(body *models.UpdatePrefsCmd, opts ...ClientOption) (*UpdateOrgPreferencesOK, error)
+	UpdateOrgPreferencesWithParams(params *UpdateOrgPreferencesParams, opts ...ClientOption) (*UpdateOrgPreferencesOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -44,7 +48,8 @@ type ClientService interface {
 GetOrgPreferences gets current org prefs
 */
 func (a *Client) GetOrgPreferences(opts ...ClientOption) (*GetOrgPreferencesOK, error) {
-	return a.GetOrgPreferencesWithParams(nil, opts...)
+	params := NewGetOrgPreferencesParams()
+	return a.GetOrgPreferencesWithParams(params, opts...)
 }
 
 func (a *Client) GetOrgPreferencesWithParams(params *GetOrgPreferencesParams, opts ...ClientOption) (*GetOrgPreferencesOK, error) {
@@ -86,7 +91,12 @@ func (a *Client) GetOrgPreferencesWithParams(params *GetOrgPreferencesParams, op
 /*
 PatchOrgPreferences patches current org prefs
 */
-func (a *Client) PatchOrgPreferences(params *PatchOrgPreferencesParams, opts ...ClientOption) (*PatchOrgPreferencesOK, error) {
+func (a *Client) PatchOrgPreferences(body *models.PatchPrefsCmd, opts ...ClientOption) (*PatchOrgPreferencesOK, error) {
+	params := NewPatchOrgPreferencesParams().WithBody(body)
+	return a.PatchOrgPreferencesWithParams(params, opts...)
+}
+
+func (a *Client) PatchOrgPreferencesWithParams(params *PatchOrgPreferencesParams, opts ...ClientOption) (*PatchOrgPreferencesOK, error) {
 	if params == nil {
 		params = NewPatchOrgPreferencesParams()
 	}
@@ -125,7 +135,12 @@ func (a *Client) PatchOrgPreferences(params *PatchOrgPreferencesParams, opts ...
 /*
 UpdateOrgPreferences updates current org prefs
 */
-func (a *Client) UpdateOrgPreferences(params *UpdateOrgPreferencesParams, opts ...ClientOption) (*UpdateOrgPreferencesOK, error) {
+func (a *Client) UpdateOrgPreferences(body *models.UpdatePrefsCmd, opts ...ClientOption) (*UpdateOrgPreferencesOK, error) {
+	params := NewUpdateOrgPreferencesParams().WithBody(body)
+	return a.UpdateOrgPreferencesWithParams(params, opts...)
+}
+
+func (a *Client) UpdateOrgPreferencesWithParams(params *UpdateOrgPreferencesParams, opts ...ClientOption) (*UpdateOrgPreferencesOK, error) {
 	if params == nil {
 		params = NewUpdateOrgPreferencesParams()
 	}

--- a/client/orgs/orgs_client.go
+++ b/client/orgs/orgs_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new orgs API client.
@@ -30,29 +32,40 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddOrgUser(params *AddOrgUserParams, opts ...ClientOption) (*AddOrgUserOK, error)
+	AddOrgUser(orgID int64, body *models.AddOrgUserCommand, opts ...ClientOption) (*AddOrgUserOK, error)
+	AddOrgUserWithParams(params *AddOrgUserParams, opts ...ClientOption) (*AddOrgUserOK, error)
 
-	CreateOrg(params *CreateOrgParams, opts ...ClientOption) (*CreateOrgOK, error)
+	CreateOrg(body *models.CreateOrgCommand, opts ...ClientOption) (*CreateOrgOK, error)
+	CreateOrgWithParams(params *CreateOrgParams, opts ...ClientOption) (*CreateOrgOK, error)
 
-	DeleteOrgByID(params *DeleteOrgByIDParams, opts ...ClientOption) (*DeleteOrgByIDOK, error)
+	DeleteOrgByID(orgID int64, opts ...ClientOption) (*DeleteOrgByIDOK, error)
+	DeleteOrgByIDWithParams(params *DeleteOrgByIDParams, opts ...ClientOption) (*DeleteOrgByIDOK, error)
 
-	GetOrgByID(params *GetOrgByIDParams, opts ...ClientOption) (*GetOrgByIDOK, error)
+	GetOrgByID(orgID int64, opts ...ClientOption) (*GetOrgByIDOK, error)
+	GetOrgByIDWithParams(params *GetOrgByIDParams, opts ...ClientOption) (*GetOrgByIDOK, error)
 
-	GetOrgByName(params *GetOrgByNameParams, opts ...ClientOption) (*GetOrgByNameOK, error)
+	GetOrgByName(orgName string, opts ...ClientOption) (*GetOrgByNameOK, error)
+	GetOrgByNameWithParams(params *GetOrgByNameParams, opts ...ClientOption) (*GetOrgByNameOK, error)
 
-	GetOrgQuota(params *GetOrgQuotaParams, opts ...ClientOption) (*GetOrgQuotaOK, error)
+	GetOrgQuota(orgID int64, opts ...ClientOption) (*GetOrgQuotaOK, error)
+	GetOrgQuotaWithParams(params *GetOrgQuotaParams, opts ...ClientOption) (*GetOrgQuotaOK, error)
 
-	GetOrgUsers(params *GetOrgUsersParams, opts ...ClientOption) (*GetOrgUsersOK, error)
+	GetOrgUsers(orgID int64, opts ...ClientOption) (*GetOrgUsersOK, error)
+	GetOrgUsersWithParams(params *GetOrgUsersParams, opts ...ClientOption) (*GetOrgUsersOK, error)
 
-	RemoveOrgUser(params *RemoveOrgUserParams, opts ...ClientOption) (*RemoveOrgUserOK, error)
+	RemoveOrgUser(userID int64, orgID int64, opts ...ClientOption) (*RemoveOrgUserOK, error)
+	RemoveOrgUserWithParams(params *RemoveOrgUserParams, opts ...ClientOption) (*RemoveOrgUserOK, error)
 
-	SearchOrgUsers(params *SearchOrgUsersParams, opts ...ClientOption) (*SearchOrgUsersOK, error)
+	SearchOrgUsers(orgID int64, opts ...ClientOption) (*SearchOrgUsersOK, error)
+	SearchOrgUsersWithParams(params *SearchOrgUsersParams, opts ...ClientOption) (*SearchOrgUsersOK, error)
 
 	SearchOrgs(params *SearchOrgsParams, opts ...ClientOption) (*SearchOrgsOK, error)
 
-	UpdateOrg(params *UpdateOrgParams, opts ...ClientOption) (*UpdateOrgOK, error)
+	UpdateOrg(orgID int64, body *models.UpdateOrgForm, opts ...ClientOption) (*UpdateOrgOK, error)
+	UpdateOrgWithParams(params *UpdateOrgParams, opts ...ClientOption) (*UpdateOrgOK, error)
 
-	UpdateOrgAddress(params *UpdateOrgAddressParams, opts ...ClientOption) (*UpdateOrgAddressOK, error)
+	UpdateOrgAddress(orgID int64, body *models.UpdateOrgAddressForm, opts ...ClientOption) (*UpdateOrgAddressOK, error)
+	UpdateOrgAddressWithParams(params *UpdateOrgAddressParams, opts ...ClientOption) (*UpdateOrgAddressOK, error)
 
 	UpdateOrgQuota(params *UpdateOrgQuotaParams, opts ...ClientOption) (*UpdateOrgQuotaOK, error)
 
@@ -62,14 +75,19 @@ type ClientService interface {
 }
 
 /*
-	AddOrgUser adds a new user to the current organization
+AddOrgUser adds a new user to the current organization
 
-	Adds a global user to the current organization.
+Adds a global user to the current organization.
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:add` with scope `users:*`.
 */
-func (a *Client) AddOrgUser(params *AddOrgUserParams, opts ...ClientOption) (*AddOrgUserOK, error) {
+func (a *Client) AddOrgUser(orgID int64, body *models.AddOrgUserCommand, opts ...ClientOption) (*AddOrgUserOK, error) {
+	params := NewAddOrgUserParams().WithBody(body).WithOrgID(orgID)
+	return a.AddOrgUserWithParams(params, opts...)
+}
+
+func (a *Client) AddOrgUserWithParams(params *AddOrgUserParams, opts ...ClientOption) (*AddOrgUserOK, error) {
 	if params == nil {
 		params = NewAddOrgUserParams()
 	}
@@ -110,7 +128,12 @@ CreateOrg creates organization
 
 Only works if [users.allow_org_create](https://grafana.com/docs/grafana/latest/administration/configuration/#allow_org_create) is set.
 */
-func (a *Client) CreateOrg(params *CreateOrgParams, opts ...ClientOption) (*CreateOrgOK, error) {
+func (a *Client) CreateOrg(body *models.CreateOrgCommand, opts ...ClientOption) (*CreateOrgOK, error) {
+	params := NewCreateOrgParams().WithBody(body)
+	return a.CreateOrgWithParams(params, opts...)
+}
+
+func (a *Client) CreateOrgWithParams(params *CreateOrgParams, opts ...ClientOption) (*CreateOrgOK, error) {
 	if params == nil {
 		params = NewCreateOrgParams()
 	}
@@ -149,7 +172,12 @@ func (a *Client) CreateOrg(params *CreateOrgParams, opts ...ClientOption) (*Crea
 /*
 DeleteOrgByID deletes organization
 */
-func (a *Client) DeleteOrgByID(params *DeleteOrgByIDParams, opts ...ClientOption) (*DeleteOrgByIDOK, error) {
+func (a *Client) DeleteOrgByID(orgID int64, opts ...ClientOption) (*DeleteOrgByIDOK, error) {
+	params := NewDeleteOrgByIDParams().WithOrgID(orgID)
+	return a.DeleteOrgByIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteOrgByIDWithParams(params *DeleteOrgByIDParams, opts ...ClientOption) (*DeleteOrgByIDOK, error) {
 	if params == nil {
 		params = NewDeleteOrgByIDParams()
 	}
@@ -188,7 +216,12 @@ func (a *Client) DeleteOrgByID(params *DeleteOrgByIDParams, opts ...ClientOption
 /*
 GetOrgByID gets organization by ID
 */
-func (a *Client) GetOrgByID(params *GetOrgByIDParams, opts ...ClientOption) (*GetOrgByIDOK, error) {
+func (a *Client) GetOrgByID(orgID int64, opts ...ClientOption) (*GetOrgByIDOK, error) {
+	params := NewGetOrgByIDParams().WithOrgID(orgID)
+	return a.GetOrgByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetOrgByIDWithParams(params *GetOrgByIDParams, opts ...ClientOption) (*GetOrgByIDOK, error) {
 	if params == nil {
 		params = NewGetOrgByIDParams()
 	}
@@ -227,7 +260,12 @@ func (a *Client) GetOrgByID(params *GetOrgByIDParams, opts ...ClientOption) (*Ge
 /*
 GetOrgByName gets organization by ID
 */
-func (a *Client) GetOrgByName(params *GetOrgByNameParams, opts ...ClientOption) (*GetOrgByNameOK, error) {
+func (a *Client) GetOrgByName(orgName string, opts ...ClientOption) (*GetOrgByNameOK, error) {
+	params := NewGetOrgByNameParams().WithOrgName(orgName)
+	return a.GetOrgByNameWithParams(params, opts...)
+}
+
+func (a *Client) GetOrgByNameWithParams(params *GetOrgByNameParams, opts ...ClientOption) (*GetOrgByNameOK, error) {
 	if params == nil {
 		params = NewGetOrgByNameParams()
 	}
@@ -268,7 +306,12 @@ GetOrgQuota fetches organization quota
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `orgs.quotas:read` and scope `org:id:1` (orgIDScope).
 */
-func (a *Client) GetOrgQuota(params *GetOrgQuotaParams, opts ...ClientOption) (*GetOrgQuotaOK, error) {
+func (a *Client) GetOrgQuota(orgID int64, opts ...ClientOption) (*GetOrgQuotaOK, error) {
+	params := NewGetOrgQuotaParams().WithOrgID(orgID)
+	return a.GetOrgQuotaWithParams(params, opts...)
+}
+
+func (a *Client) GetOrgQuotaWithParams(params *GetOrgQuotaParams, opts ...ClientOption) (*GetOrgQuotaOK, error) {
 	if params == nil {
 		params = NewGetOrgQuotaParams()
 	}
@@ -305,13 +348,17 @@ func (a *Client) GetOrgQuota(params *GetOrgQuotaParams, opts ...ClientOption) (*
 }
 
 /*
-	GetOrgUsers gets users in organization
+GetOrgUsers gets users in organization
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:read` with scope `users:*`.
 */
-func (a *Client) GetOrgUsers(params *GetOrgUsersParams, opts ...ClientOption) (*GetOrgUsersOK, error) {
+func (a *Client) GetOrgUsers(orgID int64, opts ...ClientOption) (*GetOrgUsersOK, error) {
+	params := NewGetOrgUsersParams().WithOrgID(orgID)
+	return a.GetOrgUsersWithParams(params, opts...)
+}
+
+func (a *Client) GetOrgUsersWithParams(params *GetOrgUsersParams, opts ...ClientOption) (*GetOrgUsersOK, error) {
 	if params == nil {
 		params = NewGetOrgUsersParams()
 	}
@@ -348,13 +395,17 @@ func (a *Client) GetOrgUsers(params *GetOrgUsersParams, opts ...ClientOption) (*
 }
 
 /*
-	RemoveOrgUser deletes user in current organization
+RemoveOrgUser deletes user in current organization
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:remove` with scope `users:*`.
 */
-func (a *Client) RemoveOrgUser(params *RemoveOrgUserParams, opts ...ClientOption) (*RemoveOrgUserOK, error) {
+func (a *Client) RemoveOrgUser(userID int64, orgID int64, opts ...ClientOption) (*RemoveOrgUserOK, error) {
+	params := NewRemoveOrgUserParams().WithOrgID(orgID).WithUserID(userID)
+	return a.RemoveOrgUserWithParams(params, opts...)
+}
+
+func (a *Client) RemoveOrgUserWithParams(params *RemoveOrgUserParams, opts ...ClientOption) (*RemoveOrgUserOK, error) {
 	if params == nil {
 		params = NewRemoveOrgUserParams()
 	}
@@ -391,13 +442,17 @@ func (a *Client) RemoveOrgUser(params *RemoveOrgUserParams, opts ...ClientOption
 }
 
 /*
-	SearchOrgUsers searches users in organization
+SearchOrgUsers searches users in organization
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users:read` with scope `users:*`.
 */
-func (a *Client) SearchOrgUsers(params *SearchOrgUsersParams, opts ...ClientOption) (*SearchOrgUsersOK, error) {
+func (a *Client) SearchOrgUsers(orgID int64, opts ...ClientOption) (*SearchOrgUsersOK, error) {
+	params := NewSearchOrgUsersParams().WithOrgID(orgID)
+	return a.SearchOrgUsersWithParams(params, opts...)
+}
+
+func (a *Client) SearchOrgUsersWithParams(params *SearchOrgUsersParams, opts ...ClientOption) (*SearchOrgUsersOK, error) {
 	if params == nil {
 		params = NewSearchOrgUsersParams()
 	}
@@ -436,6 +491,7 @@ func (a *Client) SearchOrgUsers(params *SearchOrgUsersParams, opts ...ClientOpti
 /*
 SearchOrgs searches all organizations
 */
+
 func (a *Client) SearchOrgs(params *SearchOrgsParams, opts ...ClientOption) (*SearchOrgsOK, error) {
 	if params == nil {
 		params = NewSearchOrgsParams()
@@ -475,7 +531,12 @@ func (a *Client) SearchOrgs(params *SearchOrgsParams, opts ...ClientOption) (*Se
 /*
 UpdateOrg updates organization
 */
-func (a *Client) UpdateOrg(params *UpdateOrgParams, opts ...ClientOption) (*UpdateOrgOK, error) {
+func (a *Client) UpdateOrg(orgID int64, body *models.UpdateOrgForm, opts ...ClientOption) (*UpdateOrgOK, error) {
+	params := NewUpdateOrgParams().WithBody(body).WithOrgID(orgID)
+	return a.UpdateOrgWithParams(params, opts...)
+}
+
+func (a *Client) UpdateOrgWithParams(params *UpdateOrgParams, opts ...ClientOption) (*UpdateOrgOK, error) {
 	if params == nil {
 		params = NewUpdateOrgParams()
 	}
@@ -514,7 +575,12 @@ func (a *Client) UpdateOrg(params *UpdateOrgParams, opts ...ClientOption) (*Upda
 /*
 UpdateOrgAddress updates organization s address
 */
-func (a *Client) UpdateOrgAddress(params *UpdateOrgAddressParams, opts ...ClientOption) (*UpdateOrgAddressOK, error) {
+func (a *Client) UpdateOrgAddress(orgID int64, body *models.UpdateOrgAddressForm, opts ...ClientOption) (*UpdateOrgAddressOK, error) {
+	params := NewUpdateOrgAddressParams().WithBody(body).WithOrgID(orgID)
+	return a.UpdateOrgAddressWithParams(params, opts...)
+}
+
+func (a *Client) UpdateOrgAddressWithParams(params *UpdateOrgAddressParams, opts ...ClientOption) (*UpdateOrgAddressOK, error) {
 	if params == nil {
 		params = NewUpdateOrgAddressParams()
 	}
@@ -555,6 +621,7 @@ UpdateOrgQuota updates user quota
 
 If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `orgs.quotas:write` and scope `org:id:1` (orgIDScope).
 */
+
 func (a *Client) UpdateOrgQuota(params *UpdateOrgQuotaParams, opts ...ClientOption) (*UpdateOrgQuotaOK, error) {
 	if params == nil {
 		params = NewUpdateOrgQuotaParams()
@@ -592,12 +659,12 @@ func (a *Client) UpdateOrgQuota(params *UpdateOrgQuotaParams, opts ...ClientOpti
 }
 
 /*
-	UpdateOrgUser updates users in organization
+UpdateOrgUser updates users in organization
 
-	If you are running Grafana Enterprise and have Fine-grained access control enabled
-
+If you are running Grafana Enterprise and have Fine-grained access control enabled
 you need to have a permission with action: `org.users.role:update` with scope `users:*`.
 */
+
 func (a *Client) UpdateOrgUser(params *UpdateOrgUserParams, opts ...ClientOption) (*UpdateOrgUserOK, error) {
 	if params == nil {
 		params = NewUpdateOrgUserParams()

--- a/client/playlists/playlists_client.go
+++ b/client/playlists/playlists_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new playlists API client.
@@ -30,17 +32,22 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreatePlaylist(params *CreatePlaylistParams, opts ...ClientOption) (*CreatePlaylistOK, error)
+	CreatePlaylist(body *models.CreatePlaylistCommand, opts ...ClientOption) (*CreatePlaylistOK, error)
+	CreatePlaylistWithParams(params *CreatePlaylistParams, opts ...ClientOption) (*CreatePlaylistOK, error)
 
-	DeletePlaylist(params *DeletePlaylistParams, opts ...ClientOption) (*DeletePlaylistOK, error)
+	DeletePlaylist(uid string, opts ...ClientOption) (*DeletePlaylistOK, error)
+	DeletePlaylistWithParams(params *DeletePlaylistParams, opts ...ClientOption) (*DeletePlaylistOK, error)
 
-	GetPlaylist(params *GetPlaylistParams, opts ...ClientOption) (*GetPlaylistOK, error)
+	GetPlaylist(uid string, opts ...ClientOption) (*GetPlaylistOK, error)
+	GetPlaylistWithParams(params *GetPlaylistParams, opts ...ClientOption) (*GetPlaylistOK, error)
 
-	GetPlaylistItems(params *GetPlaylistItemsParams, opts ...ClientOption) (*GetPlaylistItemsOK, error)
+	GetPlaylistItems(uid string, opts ...ClientOption) (*GetPlaylistItemsOK, error)
+	GetPlaylistItemsWithParams(params *GetPlaylistItemsParams, opts ...ClientOption) (*GetPlaylistItemsOK, error)
 
 	SearchPlaylists(params *SearchPlaylistsParams, opts ...ClientOption) (*SearchPlaylistsOK, error)
 
-	UpdatePlaylist(params *UpdatePlaylistParams, opts ...ClientOption) (*UpdatePlaylistOK, error)
+	UpdatePlaylist(uid string, body *models.UpdatePlaylistCommand, opts ...ClientOption) (*UpdatePlaylistOK, error)
+	UpdatePlaylistWithParams(params *UpdatePlaylistParams, opts ...ClientOption) (*UpdatePlaylistOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -48,7 +55,12 @@ type ClientService interface {
 /*
 CreatePlaylist creates playlist
 */
-func (a *Client) CreatePlaylist(params *CreatePlaylistParams, opts ...ClientOption) (*CreatePlaylistOK, error) {
+func (a *Client) CreatePlaylist(body *models.CreatePlaylistCommand, opts ...ClientOption) (*CreatePlaylistOK, error) {
+	params := NewCreatePlaylistParams().WithBody(body)
+	return a.CreatePlaylistWithParams(params, opts...)
+}
+
+func (a *Client) CreatePlaylistWithParams(params *CreatePlaylistParams, opts ...ClientOption) (*CreatePlaylistOK, error) {
 	if params == nil {
 		params = NewCreatePlaylistParams()
 	}
@@ -87,7 +99,12 @@ func (a *Client) CreatePlaylist(params *CreatePlaylistParams, opts ...ClientOpti
 /*
 DeletePlaylist deletes playlist
 */
-func (a *Client) DeletePlaylist(params *DeletePlaylistParams, opts ...ClientOption) (*DeletePlaylistOK, error) {
+func (a *Client) DeletePlaylist(uid string, opts ...ClientOption) (*DeletePlaylistOK, error) {
+	params := NewDeletePlaylistParams().WithUID(uid)
+	return a.DeletePlaylistWithParams(params, opts...)
+}
+
+func (a *Client) DeletePlaylistWithParams(params *DeletePlaylistParams, opts ...ClientOption) (*DeletePlaylistOK, error) {
 	if params == nil {
 		params = NewDeletePlaylistParams()
 	}
@@ -126,7 +143,12 @@ func (a *Client) DeletePlaylist(params *DeletePlaylistParams, opts ...ClientOpti
 /*
 GetPlaylist gets playlist
 */
-func (a *Client) GetPlaylist(params *GetPlaylistParams, opts ...ClientOption) (*GetPlaylistOK, error) {
+func (a *Client) GetPlaylist(uid string, opts ...ClientOption) (*GetPlaylistOK, error) {
+	params := NewGetPlaylistParams().WithUID(uid)
+	return a.GetPlaylistWithParams(params, opts...)
+}
+
+func (a *Client) GetPlaylistWithParams(params *GetPlaylistParams, opts ...ClientOption) (*GetPlaylistOK, error) {
 	if params == nil {
 		params = NewGetPlaylistParams()
 	}
@@ -165,7 +187,12 @@ func (a *Client) GetPlaylist(params *GetPlaylistParams, opts ...ClientOption) (*
 /*
 GetPlaylistItems gets playlist items
 */
-func (a *Client) GetPlaylistItems(params *GetPlaylistItemsParams, opts ...ClientOption) (*GetPlaylistItemsOK, error) {
+func (a *Client) GetPlaylistItems(uid string, opts ...ClientOption) (*GetPlaylistItemsOK, error) {
+	params := NewGetPlaylistItemsParams().WithUID(uid)
+	return a.GetPlaylistItemsWithParams(params, opts...)
+}
+
+func (a *Client) GetPlaylistItemsWithParams(params *GetPlaylistItemsParams, opts ...ClientOption) (*GetPlaylistItemsOK, error) {
 	if params == nil {
 		params = NewGetPlaylistItemsParams()
 	}
@@ -204,6 +231,7 @@ func (a *Client) GetPlaylistItems(params *GetPlaylistItemsParams, opts ...Client
 /*
 SearchPlaylists gets playlists
 */
+
 func (a *Client) SearchPlaylists(params *SearchPlaylistsParams, opts ...ClientOption) (*SearchPlaylistsOK, error) {
 	if params == nil {
 		params = NewSearchPlaylistsParams()
@@ -243,7 +271,12 @@ func (a *Client) SearchPlaylists(params *SearchPlaylistsParams, opts ...ClientOp
 /*
 UpdatePlaylist updates playlist
 */
-func (a *Client) UpdatePlaylist(params *UpdatePlaylistParams, opts ...ClientOption) (*UpdatePlaylistOK, error) {
+func (a *Client) UpdatePlaylist(uid string, body *models.UpdatePlaylistCommand, opts ...ClientOption) (*UpdatePlaylistOK, error) {
+	params := NewUpdatePlaylistParams().WithBody(body).WithUID(uid)
+	return a.UpdatePlaylistWithParams(params, opts...)
+}
+
+func (a *Client) UpdatePlaylistWithParams(params *UpdatePlaylistParams, opts ...ClientOption) (*UpdatePlaylistOK, error) {
 	if params == nil {
 		params = NewUpdatePlaylistParams()
 	}

--- a/client/provisioning/provisioning_client.go
+++ b/client/provisioning/provisioning_client.go
@@ -30,19 +30,25 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DeleteAlertRule(params *DeleteAlertRuleParams, opts ...ClientOption) (*DeleteAlertRuleNoContent, error)
+	DeleteAlertRule(uid string, opts ...ClientOption) (*DeleteAlertRuleNoContent, error)
+	DeleteAlertRuleWithParams(params *DeleteAlertRuleParams, opts ...ClientOption) (*DeleteAlertRuleNoContent, error)
 
-	DeleteContactpoints(params *DeleteContactpointsParams, opts ...ClientOption) (*DeleteContactpointsNoContent, error)
+	DeleteContactpoints(uid string, opts ...ClientOption) (*DeleteContactpointsNoContent, error)
+	DeleteContactpointsWithParams(params *DeleteContactpointsParams, opts ...ClientOption) (*DeleteContactpointsNoContent, error)
 
-	DeleteMuteTiming(params *DeleteMuteTimingParams, opts ...ClientOption) (*DeleteMuteTimingNoContent, error)
+	DeleteMuteTiming(name string, opts ...ClientOption) (*DeleteMuteTimingNoContent, error)
+	DeleteMuteTimingWithParams(params *DeleteMuteTimingParams, opts ...ClientOption) (*DeleteMuteTimingNoContent, error)
 
-	DeleteTemplate(params *DeleteTemplateParams, opts ...ClientOption) (*DeleteTemplateNoContent, error)
+	DeleteTemplate(name string, opts ...ClientOption) (*DeleteTemplateNoContent, error)
+	DeleteTemplateWithParams(params *DeleteTemplateParams, opts ...ClientOption) (*DeleteTemplateNoContent, error)
 
-	GetAlertRule(params *GetAlertRuleParams, opts ...ClientOption) (*GetAlertRuleOK, error)
+	GetAlertRule(uid string, opts ...ClientOption) (*GetAlertRuleOK, error)
+	GetAlertRuleWithParams(params *GetAlertRuleParams, opts ...ClientOption) (*GetAlertRuleOK, error)
 
 	GetAlertRuleExport(params *GetAlertRuleExportParams, opts ...ClientOption) (*GetAlertRuleExportOK, error)
 
-	GetAlertRuleGroup(params *GetAlertRuleGroupParams, opts ...ClientOption) (*GetAlertRuleGroupOK, error)
+	GetAlertRuleGroup(group string, folderUID string, opts ...ClientOption) (*GetAlertRuleGroupOK, error)
+	GetAlertRuleGroupWithParams(params *GetAlertRuleGroupParams, opts ...ClientOption) (*GetAlertRuleGroupOK, error)
 
 	GetAlertRuleGroupExport(params *GetAlertRuleGroupExportParams, opts ...ClientOption) (*GetAlertRuleGroupExportOK, error)
 
@@ -55,7 +61,8 @@ type ClientService interface {
 
 	GetContactpointsExport(params *GetContactpointsExportParams, opts ...ClientOption) (*GetContactpointsExportOK, error)
 
-	GetMuteTiming(params *GetMuteTimingParams, opts ...ClientOption) (*GetMuteTimingOK, error)
+	GetMuteTiming(name string, opts ...ClientOption) (*GetMuteTimingOK, error)
+	GetMuteTimingWithParams(params *GetMuteTimingParams, opts ...ClientOption) (*GetMuteTimingOK, error)
 
 	GetMuteTimings(opts ...ClientOption) (*GetMuteTimingsOK, error)
 	GetMuteTimingsWithParams(params *GetMuteTimingsParams, opts ...ClientOption) (*GetMuteTimingsOK, error)
@@ -66,7 +73,8 @@ type ClientService interface {
 	GetPolicyTreeExport(opts ...ClientOption) (*GetPolicyTreeExportOK, error)
 	GetPolicyTreeExportWithParams(params *GetPolicyTreeExportParams, opts ...ClientOption) (*GetPolicyTreeExportOK, error)
 
-	GetTemplate(params *GetTemplateParams, opts ...ClientOption) (*GetTemplateOK, error)
+	GetTemplate(name string, opts ...ClientOption) (*GetTemplateOK, error)
+	GetTemplateWithParams(params *GetTemplateParams, opts ...ClientOption) (*GetTemplateOK, error)
 
 	GetTemplates(opts ...ClientOption) (*GetTemplatesOK, error)
 	GetTemplatesWithParams(params *GetTemplatesParams, opts ...ClientOption) (*GetTemplatesOK, error)
@@ -98,7 +106,12 @@ type ClientService interface {
 /*
 DeleteAlertRule deletes a specific alert rule by UID
 */
-func (a *Client) DeleteAlertRule(params *DeleteAlertRuleParams, opts ...ClientOption) (*DeleteAlertRuleNoContent, error) {
+func (a *Client) DeleteAlertRule(uid string, opts ...ClientOption) (*DeleteAlertRuleNoContent, error) {
+	params := NewDeleteAlertRuleParams().WithUID(uid)
+	return a.DeleteAlertRuleWithParams(params, opts...)
+}
+
+func (a *Client) DeleteAlertRuleWithParams(params *DeleteAlertRuleParams, opts ...ClientOption) (*DeleteAlertRuleNoContent, error) {
 	if params == nil {
 		params = NewDeleteAlertRuleParams()
 	}
@@ -137,7 +150,12 @@ func (a *Client) DeleteAlertRule(params *DeleteAlertRuleParams, opts ...ClientOp
 /*
 DeleteContactpoints deletes a contact point
 */
-func (a *Client) DeleteContactpoints(params *DeleteContactpointsParams, opts ...ClientOption) (*DeleteContactpointsNoContent, error) {
+func (a *Client) DeleteContactpoints(uid string, opts ...ClientOption) (*DeleteContactpointsNoContent, error) {
+	params := NewDeleteContactpointsParams().WithUID(uid)
+	return a.DeleteContactpointsWithParams(params, opts...)
+}
+
+func (a *Client) DeleteContactpointsWithParams(params *DeleteContactpointsParams, opts ...ClientOption) (*DeleteContactpointsNoContent, error) {
 	if params == nil {
 		params = NewDeleteContactpointsParams()
 	}
@@ -176,7 +194,12 @@ func (a *Client) DeleteContactpoints(params *DeleteContactpointsParams, opts ...
 /*
 DeleteMuteTiming deletes a mute timing
 */
-func (a *Client) DeleteMuteTiming(params *DeleteMuteTimingParams, opts ...ClientOption) (*DeleteMuteTimingNoContent, error) {
+func (a *Client) DeleteMuteTiming(name string, opts ...ClientOption) (*DeleteMuteTimingNoContent, error) {
+	params := NewDeleteMuteTimingParams().WithName(name)
+	return a.DeleteMuteTimingWithParams(params, opts...)
+}
+
+func (a *Client) DeleteMuteTimingWithParams(params *DeleteMuteTimingParams, opts ...ClientOption) (*DeleteMuteTimingNoContent, error) {
 	if params == nil {
 		params = NewDeleteMuteTimingParams()
 	}
@@ -215,7 +238,12 @@ func (a *Client) DeleteMuteTiming(params *DeleteMuteTimingParams, opts ...Client
 /*
 DeleteTemplate deletes a template
 */
-func (a *Client) DeleteTemplate(params *DeleteTemplateParams, opts ...ClientOption) (*DeleteTemplateNoContent, error) {
+func (a *Client) DeleteTemplate(name string, opts ...ClientOption) (*DeleteTemplateNoContent, error) {
+	params := NewDeleteTemplateParams().WithName(name)
+	return a.DeleteTemplateWithParams(params, opts...)
+}
+
+func (a *Client) DeleteTemplateWithParams(params *DeleteTemplateParams, opts ...ClientOption) (*DeleteTemplateNoContent, error) {
 	if params == nil {
 		params = NewDeleteTemplateParams()
 	}
@@ -254,7 +282,12 @@ func (a *Client) DeleteTemplate(params *DeleteTemplateParams, opts ...ClientOpti
 /*
 GetAlertRule gets a specific alert rule by UID
 */
-func (a *Client) GetAlertRule(params *GetAlertRuleParams, opts ...ClientOption) (*GetAlertRuleOK, error) {
+func (a *Client) GetAlertRule(uid string, opts ...ClientOption) (*GetAlertRuleOK, error) {
+	params := NewGetAlertRuleParams().WithUID(uid)
+	return a.GetAlertRuleWithParams(params, opts...)
+}
+
+func (a *Client) GetAlertRuleWithParams(params *GetAlertRuleParams, opts ...ClientOption) (*GetAlertRuleOK, error) {
 	if params == nil {
 		params = NewGetAlertRuleParams()
 	}
@@ -293,6 +326,7 @@ func (a *Client) GetAlertRule(params *GetAlertRuleParams, opts ...ClientOption) 
 /*
 GetAlertRuleExport exports an alert rule in provisioning file format
 */
+
 func (a *Client) GetAlertRuleExport(params *GetAlertRuleExportParams, opts ...ClientOption) (*GetAlertRuleExportOK, error) {
 	if params == nil {
 		params = NewGetAlertRuleExportParams()
@@ -332,7 +366,12 @@ func (a *Client) GetAlertRuleExport(params *GetAlertRuleExportParams, opts ...Cl
 /*
 GetAlertRuleGroup gets a rule group
 */
-func (a *Client) GetAlertRuleGroup(params *GetAlertRuleGroupParams, opts ...ClientOption) (*GetAlertRuleGroupOK, error) {
+func (a *Client) GetAlertRuleGroup(group string, folderUID string, opts ...ClientOption) (*GetAlertRuleGroupOK, error) {
+	params := NewGetAlertRuleGroupParams().WithFolderUID(folderUID).WithGroup(group)
+	return a.GetAlertRuleGroupWithParams(params, opts...)
+}
+
+func (a *Client) GetAlertRuleGroupWithParams(params *GetAlertRuleGroupParams, opts ...ClientOption) (*GetAlertRuleGroupOK, error) {
 	if params == nil {
 		params = NewGetAlertRuleGroupParams()
 	}
@@ -371,6 +410,7 @@ func (a *Client) GetAlertRuleGroup(params *GetAlertRuleGroupParams, opts ...Clie
 /*
 GetAlertRuleGroupExport exports an alert rule group in provisioning file format
 */
+
 func (a *Client) GetAlertRuleGroupExport(params *GetAlertRuleGroupExportParams, opts ...ClientOption) (*GetAlertRuleGroupExportOK, error) {
 	if params == nil {
 		params = NewGetAlertRuleGroupExportParams()
@@ -411,7 +451,8 @@ func (a *Client) GetAlertRuleGroupExport(params *GetAlertRuleGroupExportParams, 
 GetAlertRules gets all the alert rules
 */
 func (a *Client) GetAlertRules(opts ...ClientOption) (*GetAlertRulesOK, error) {
-	return a.GetAlertRulesWithParams(nil, opts...)
+	params := NewGetAlertRulesParams()
+	return a.GetAlertRulesWithParams(params, opts...)
 }
 
 func (a *Client) GetAlertRulesWithParams(params *GetAlertRulesParams, opts ...ClientOption) (*GetAlertRulesOK, error) {
@@ -453,6 +494,7 @@ func (a *Client) GetAlertRulesWithParams(params *GetAlertRulesParams, opts ...Cl
 /*
 GetAlertRulesExport exports all alert rules in provisioning file format
 */
+
 func (a *Client) GetAlertRulesExport(params *GetAlertRulesExportParams, opts ...ClientOption) (*GetAlertRulesExportOK, error) {
 	if params == nil {
 		params = NewGetAlertRulesExportParams()
@@ -492,6 +534,7 @@ func (a *Client) GetAlertRulesExport(params *GetAlertRulesExportParams, opts ...
 /*
 GetContactpoints gets all the contact points
 */
+
 func (a *Client) GetContactpoints(params *GetContactpointsParams, opts ...ClientOption) (*GetContactpointsOK, error) {
 	if params == nil {
 		params = NewGetContactpointsParams()
@@ -531,6 +574,7 @@ func (a *Client) GetContactpoints(params *GetContactpointsParams, opts ...Client
 /*
 GetContactpointsExport exports all contact points in provisioning file format
 */
+
 func (a *Client) GetContactpointsExport(params *GetContactpointsExportParams, opts ...ClientOption) (*GetContactpointsExportOK, error) {
 	if params == nil {
 		params = NewGetContactpointsExportParams()
@@ -570,7 +614,12 @@ func (a *Client) GetContactpointsExport(params *GetContactpointsExportParams, op
 /*
 GetMuteTiming gets a mute timing
 */
-func (a *Client) GetMuteTiming(params *GetMuteTimingParams, opts ...ClientOption) (*GetMuteTimingOK, error) {
+func (a *Client) GetMuteTiming(name string, opts ...ClientOption) (*GetMuteTimingOK, error) {
+	params := NewGetMuteTimingParams().WithName(name)
+	return a.GetMuteTimingWithParams(params, opts...)
+}
+
+func (a *Client) GetMuteTimingWithParams(params *GetMuteTimingParams, opts ...ClientOption) (*GetMuteTimingOK, error) {
 	if params == nil {
 		params = NewGetMuteTimingParams()
 	}
@@ -610,7 +659,8 @@ func (a *Client) GetMuteTiming(params *GetMuteTimingParams, opts ...ClientOption
 GetMuteTimings gets all the mute timings
 */
 func (a *Client) GetMuteTimings(opts ...ClientOption) (*GetMuteTimingsOK, error) {
-	return a.GetMuteTimingsWithParams(nil, opts...)
+	params := NewGetMuteTimingsParams()
+	return a.GetMuteTimingsWithParams(params, opts...)
 }
 
 func (a *Client) GetMuteTimingsWithParams(params *GetMuteTimingsParams, opts ...ClientOption) (*GetMuteTimingsOK, error) {
@@ -653,7 +703,8 @@ func (a *Client) GetMuteTimingsWithParams(params *GetMuteTimingsParams, opts ...
 GetPolicyTree gets the notification policy tree
 */
 func (a *Client) GetPolicyTree(opts ...ClientOption) (*GetPolicyTreeOK, error) {
-	return a.GetPolicyTreeWithParams(nil, opts...)
+	params := NewGetPolicyTreeParams()
+	return a.GetPolicyTreeWithParams(params, opts...)
 }
 
 func (a *Client) GetPolicyTreeWithParams(params *GetPolicyTreeParams, opts ...ClientOption) (*GetPolicyTreeOK, error) {
@@ -696,7 +747,8 @@ func (a *Client) GetPolicyTreeWithParams(params *GetPolicyTreeParams, opts ...Cl
 GetPolicyTreeExport exports the notification policy tree in provisioning file format
 */
 func (a *Client) GetPolicyTreeExport(opts ...ClientOption) (*GetPolicyTreeExportOK, error) {
-	return a.GetPolicyTreeExportWithParams(nil, opts...)
+	params := NewGetPolicyTreeExportParams()
+	return a.GetPolicyTreeExportWithParams(params, opts...)
 }
 
 func (a *Client) GetPolicyTreeExportWithParams(params *GetPolicyTreeExportParams, opts ...ClientOption) (*GetPolicyTreeExportOK, error) {
@@ -738,7 +790,12 @@ func (a *Client) GetPolicyTreeExportWithParams(params *GetPolicyTreeExportParams
 /*
 GetTemplate gets a notification template
 */
-func (a *Client) GetTemplate(params *GetTemplateParams, opts ...ClientOption) (*GetTemplateOK, error) {
+func (a *Client) GetTemplate(name string, opts ...ClientOption) (*GetTemplateOK, error) {
+	params := NewGetTemplateParams().WithName(name)
+	return a.GetTemplateWithParams(params, opts...)
+}
+
+func (a *Client) GetTemplateWithParams(params *GetTemplateParams, opts ...ClientOption) (*GetTemplateOK, error) {
 	if params == nil {
 		params = NewGetTemplateParams()
 	}
@@ -778,7 +835,8 @@ func (a *Client) GetTemplate(params *GetTemplateParams, opts ...ClientOption) (*
 GetTemplates gets all notification templates
 */
 func (a *Client) GetTemplates(opts ...ClientOption) (*GetTemplatesOK, error) {
-	return a.GetTemplatesWithParams(nil, opts...)
+	params := NewGetTemplatesParams()
+	return a.GetTemplatesWithParams(params, opts...)
 }
 
 func (a *Client) GetTemplatesWithParams(params *GetTemplatesParams, opts ...ClientOption) (*GetTemplatesOK, error) {
@@ -820,6 +878,7 @@ func (a *Client) GetTemplatesWithParams(params *GetTemplatesParams, opts ...Clie
 /*
 PostAlertRule creates a new alert rule
 */
+
 func (a *Client) PostAlertRule(params *PostAlertRuleParams, opts ...ClientOption) (*PostAlertRuleCreated, error) {
 	if params == nil {
 		params = NewPostAlertRuleParams()
@@ -859,6 +918,7 @@ func (a *Client) PostAlertRule(params *PostAlertRuleParams, opts ...ClientOption
 /*
 PostContactpoints creates a contact point
 */
+
 func (a *Client) PostContactpoints(params *PostContactpointsParams, opts ...ClientOption) (*PostContactpointsAccepted, error) {
 	if params == nil {
 		params = NewPostContactpointsParams()
@@ -898,6 +958,7 @@ func (a *Client) PostContactpoints(params *PostContactpointsParams, opts ...Clie
 /*
 PostMuteTiming creates a new mute timing
 */
+
 func (a *Client) PostMuteTiming(params *PostMuteTimingParams, opts ...ClientOption) (*PostMuteTimingCreated, error) {
 	if params == nil {
 		params = NewPostMuteTimingParams()
@@ -937,6 +998,7 @@ func (a *Client) PostMuteTiming(params *PostMuteTimingParams, opts ...ClientOpti
 /*
 PutAlertRule updates an existing alert rule
 */
+
 func (a *Client) PutAlertRule(params *PutAlertRuleParams, opts ...ClientOption) (*PutAlertRuleOK, error) {
 	if params == nil {
 		params = NewPutAlertRuleParams()
@@ -976,6 +1038,7 @@ func (a *Client) PutAlertRule(params *PutAlertRuleParams, opts ...ClientOption) 
 /*
 PutAlertRuleGroup updates the interval of a rule group
 */
+
 func (a *Client) PutAlertRuleGroup(params *PutAlertRuleGroupParams, opts ...ClientOption) (*PutAlertRuleGroupOK, error) {
 	if params == nil {
 		params = NewPutAlertRuleGroupParams()
@@ -1015,6 +1078,7 @@ func (a *Client) PutAlertRuleGroup(params *PutAlertRuleGroupParams, opts ...Clie
 /*
 PutContactpoint updates an existing contact point
 */
+
 func (a *Client) PutContactpoint(params *PutContactpointParams, opts ...ClientOption) (*PutContactpointAccepted, error) {
 	if params == nil {
 		params = NewPutContactpointParams()
@@ -1054,6 +1118,7 @@ func (a *Client) PutContactpoint(params *PutContactpointParams, opts ...ClientOp
 /*
 PutMuteTiming replaces an existing mute timing
 */
+
 func (a *Client) PutMuteTiming(params *PutMuteTimingParams, opts ...ClientOption) (*PutMuteTimingOK, error) {
 	if params == nil {
 		params = NewPutMuteTimingParams()
@@ -1093,6 +1158,7 @@ func (a *Client) PutMuteTiming(params *PutMuteTimingParams, opts ...ClientOption
 /*
 PutPolicyTree sets the notification policy tree
 */
+
 func (a *Client) PutPolicyTree(params *PutPolicyTreeParams, opts ...ClientOption) (*PutPolicyTreeAccepted, error) {
 	if params == nil {
 		params = NewPutPolicyTreeParams()
@@ -1132,6 +1198,7 @@ func (a *Client) PutPolicyTree(params *PutPolicyTreeParams, opts ...ClientOption
 /*
 PutTemplate updates an existing notification template
 */
+
 func (a *Client) PutTemplate(params *PutTemplateParams, opts ...ClientOption) (*PutTemplateAccepted, error) {
 	if params == nil {
 		params = NewPutTemplateParams()
@@ -1172,7 +1239,8 @@ func (a *Client) PutTemplate(params *PutTemplateParams, opts ...ClientOption) (*
 ResetPolicyTree clears the notification policy tree
 */
 func (a *Client) ResetPolicyTree(opts ...ClientOption) (*ResetPolicyTreeAccepted, error) {
-	return a.ResetPolicyTreeWithParams(nil, opts...)
+	params := NewResetPolicyTreeParams()
+	return a.ResetPolicyTreeWithParams(params, opts...)
 }
 
 func (a *Client) ResetPolicyTreeWithParams(params *ResetPolicyTreeParams, opts ...ClientOption) (*ResetPolicyTreeAccepted, error) {

--- a/client/query_history/query_history_client.go
+++ b/client/query_history/query_history_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new query history API client.
@@ -30,17 +32,22 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateQuery(params *CreateQueryParams, opts ...ClientOption) (*CreateQueryOK, error)
+	CreateQuery(body *models.CreateQueryInQueryHistoryCommand, opts ...ClientOption) (*CreateQueryOK, error)
+	CreateQueryWithParams(params *CreateQueryParams, opts ...ClientOption) (*CreateQueryOK, error)
 
-	DeleteQuery(params *DeleteQueryParams, opts ...ClientOption) (*DeleteQueryOK, error)
+	DeleteQuery(queryHistoryUID string, opts ...ClientOption) (*DeleteQueryOK, error)
+	DeleteQueryWithParams(params *DeleteQueryParams, opts ...ClientOption) (*DeleteQueryOK, error)
 
-	PatchQueryComment(params *PatchQueryCommentParams, opts ...ClientOption) (*PatchQueryCommentOK, error)
+	PatchQueryComment(queryHistoryUID string, body *models.PatchQueryCommentInQueryHistoryCommand, opts ...ClientOption) (*PatchQueryCommentOK, error)
+	PatchQueryCommentWithParams(params *PatchQueryCommentParams, opts ...ClientOption) (*PatchQueryCommentOK, error)
 
 	SearchQueries(params *SearchQueriesParams, opts ...ClientOption) (*SearchQueriesOK, error)
 
-	StarQuery(params *StarQueryParams, opts ...ClientOption) (*StarQueryOK, error)
+	StarQuery(queryHistoryUID string, opts ...ClientOption) (*StarQueryOK, error)
+	StarQueryWithParams(params *StarQueryParams, opts ...ClientOption) (*StarQueryOK, error)
 
-	UnstarQuery(params *UnstarQueryParams, opts ...ClientOption) (*UnstarQueryOK, error)
+	UnstarQuery(queryHistoryUID string, opts ...ClientOption) (*UnstarQueryOK, error)
+	UnstarQueryWithParams(params *UnstarQueryParams, opts ...ClientOption) (*UnstarQueryOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -50,7 +57,12 @@ CreateQuery adds query to query history
 
 Adds new query to query history.
 */
-func (a *Client) CreateQuery(params *CreateQueryParams, opts ...ClientOption) (*CreateQueryOK, error) {
+func (a *Client) CreateQuery(body *models.CreateQueryInQueryHistoryCommand, opts ...ClientOption) (*CreateQueryOK, error) {
+	params := NewCreateQueryParams().WithBody(body)
+	return a.CreateQueryWithParams(params, opts...)
+}
+
+func (a *Client) CreateQueryWithParams(params *CreateQueryParams, opts ...ClientOption) (*CreateQueryOK, error) {
 	if params == nil {
 		params = NewCreateQueryParams()
 	}
@@ -91,7 +103,12 @@ DeleteQuery deletes query in query history
 
 Deletes an existing query in query history as specified by the UID. This operation cannot be reverted.
 */
-func (a *Client) DeleteQuery(params *DeleteQueryParams, opts ...ClientOption) (*DeleteQueryOK, error) {
+func (a *Client) DeleteQuery(queryHistoryUID string, opts ...ClientOption) (*DeleteQueryOK, error) {
+	params := NewDeleteQueryParams().WithQueryHistoryUID(queryHistoryUID)
+	return a.DeleteQueryWithParams(params, opts...)
+}
+
+func (a *Client) DeleteQueryWithParams(params *DeleteQueryParams, opts ...ClientOption) (*DeleteQueryOK, error) {
 	if params == nil {
 		params = NewDeleteQueryParams()
 	}
@@ -132,7 +149,12 @@ PatchQueryComment updates comment for query in query history
 
 Updates comment for query in query history as specified by the UID.
 */
-func (a *Client) PatchQueryComment(params *PatchQueryCommentParams, opts ...ClientOption) (*PatchQueryCommentOK, error) {
+func (a *Client) PatchQueryComment(queryHistoryUID string, body *models.PatchQueryCommentInQueryHistoryCommand, opts ...ClientOption) (*PatchQueryCommentOK, error) {
+	params := NewPatchQueryCommentParams().WithBody(body).WithQueryHistoryUID(queryHistoryUID)
+	return a.PatchQueryCommentWithParams(params, opts...)
+}
+
+func (a *Client) PatchQueryCommentWithParams(params *PatchQueryCommentParams, opts ...ClientOption) (*PatchQueryCommentOK, error) {
 	if params == nil {
 		params = NewPatchQueryCommentParams()
 	}
@@ -169,13 +191,13 @@ func (a *Client) PatchQueryComment(params *PatchQueryCommentParams, opts ...Clie
 }
 
 /*
-	SearchQueries queries history search
+SearchQueries queries history search
 
-	Returns a list of queries in the query history that matches the search criteria.
-
+Returns a list of queries in the query history that matches the search criteria.
 Query history search supports pagination. Use the `limit` parameter to control the maximum number of queries returned; the default limit is 100.
 You can also use the `page` query parameter to fetch queries from any page other than the first one.
 */
+
 func (a *Client) SearchQueries(params *SearchQueriesParams, opts ...ClientOption) (*SearchQueriesOK, error) {
 	if params == nil {
 		params = NewSearchQueriesParams()
@@ -217,7 +239,12 @@ StarQuery adds star to query in query history
 
 Adds star to query in query history as specified by the UID.
 */
-func (a *Client) StarQuery(params *StarQueryParams, opts ...ClientOption) (*StarQueryOK, error) {
+func (a *Client) StarQuery(queryHistoryUID string, opts ...ClientOption) (*StarQueryOK, error) {
+	params := NewStarQueryParams().WithQueryHistoryUID(queryHistoryUID)
+	return a.StarQueryWithParams(params, opts...)
+}
+
+func (a *Client) StarQueryWithParams(params *StarQueryParams, opts ...ClientOption) (*StarQueryOK, error) {
 	if params == nil {
 		params = NewStarQueryParams()
 	}
@@ -258,7 +285,12 @@ UnstarQuery removes star to query in query history
 
 Removes star from query in query history as specified by the UID.
 */
-func (a *Client) UnstarQuery(params *UnstarQueryParams, opts ...ClientOption) (*UnstarQueryOK, error) {
+func (a *Client) UnstarQuery(queryHistoryUID string, opts ...ClientOption) (*UnstarQueryOK, error) {
+	params := NewUnstarQueryParams().WithQueryHistoryUID(queryHistoryUID)
+	return a.UnstarQueryWithParams(params, opts...)
+}
+
+func (a *Client) UnstarQueryWithParams(params *UnstarQueryParams, opts ...ClientOption) (*UnstarQueryOK, error) {
 	if params == nil {
 		params = NewUnstarQueryParams()
 	}

--- a/client/recording_rules/recording_rules_client.go
+++ b/client/recording_rules/recording_rules_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new recording rules API client.
@@ -30,11 +32,14 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateRecordingRule(params *CreateRecordingRuleParams, opts ...ClientOption) (*CreateRecordingRuleOK, error)
+	CreateRecordingRule(body *models.RecordingRuleJSON, opts ...ClientOption) (*CreateRecordingRuleOK, error)
+	CreateRecordingRuleWithParams(params *CreateRecordingRuleParams, opts ...ClientOption) (*CreateRecordingRuleOK, error)
 
-	CreateRecordingRuleWriteTarget(params *CreateRecordingRuleWriteTargetParams, opts ...ClientOption) (*CreateRecordingRuleWriteTargetOK, error)
+	CreateRecordingRuleWriteTarget(body *models.PrometheusRemoteWriteTargetJSON, opts ...ClientOption) (*CreateRecordingRuleWriteTargetOK, error)
+	CreateRecordingRuleWriteTargetWithParams(params *CreateRecordingRuleWriteTargetParams, opts ...ClientOption) (*CreateRecordingRuleWriteTargetOK, error)
 
-	DeleteRecordingRule(params *DeleteRecordingRuleParams, opts ...ClientOption) (*DeleteRecordingRuleOK, error)
+	DeleteRecordingRule(recordingRuleID int64, opts ...ClientOption) (*DeleteRecordingRuleOK, error)
+	DeleteRecordingRuleWithParams(params *DeleteRecordingRuleParams, opts ...ClientOption) (*DeleteRecordingRuleOK, error)
 
 	DeleteRecordingRuleWriteTarget(opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error)
 	DeleteRecordingRuleWriteTargetWithParams(params *DeleteRecordingRuleWriteTargetParams, opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error)
@@ -45,9 +50,11 @@ type ClientService interface {
 	ListRecordingRules(opts ...ClientOption) (*ListRecordingRulesOK, error)
 	ListRecordingRulesWithParams(params *ListRecordingRulesParams, opts ...ClientOption) (*ListRecordingRulesOK, error)
 
-	TestCreateRecordingRule(params *TestCreateRecordingRuleParams, opts ...ClientOption) (*TestCreateRecordingRuleOK, error)
+	TestCreateRecordingRule(body *models.RecordingRuleJSON, opts ...ClientOption) (*TestCreateRecordingRuleOK, error)
+	TestCreateRecordingRuleWithParams(params *TestCreateRecordingRuleParams, opts ...ClientOption) (*TestCreateRecordingRuleOK, error)
 
-	UpdateRecordingRule(params *UpdateRecordingRuleParams, opts ...ClientOption) (*UpdateRecordingRuleOK, error)
+	UpdateRecordingRule(body *models.RecordingRuleJSON, opts ...ClientOption) (*UpdateRecordingRuleOK, error)
+	UpdateRecordingRuleWithParams(params *UpdateRecordingRuleParams, opts ...ClientOption) (*UpdateRecordingRuleOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -55,7 +62,12 @@ type ClientService interface {
 /*
 CreateRecordingRule creates a recording rule that is then registered and started
 */
-func (a *Client) CreateRecordingRule(params *CreateRecordingRuleParams, opts ...ClientOption) (*CreateRecordingRuleOK, error) {
+func (a *Client) CreateRecordingRule(body *models.RecordingRuleJSON, opts ...ClientOption) (*CreateRecordingRuleOK, error) {
+	params := NewCreateRecordingRuleParams().WithBody(body)
+	return a.CreateRecordingRuleWithParams(params, opts...)
+}
+
+func (a *Client) CreateRecordingRuleWithParams(params *CreateRecordingRuleParams, opts ...ClientOption) (*CreateRecordingRuleOK, error) {
 	if params == nil {
 		params = NewCreateRecordingRuleParams()
 	}
@@ -96,7 +108,12 @@ CreateRecordingRuleWriteTarget creates a remote write target
 
 It returns a 422 if there is not an existing prometheus data source configured.
 */
-func (a *Client) CreateRecordingRuleWriteTarget(params *CreateRecordingRuleWriteTargetParams, opts ...ClientOption) (*CreateRecordingRuleWriteTargetOK, error) {
+func (a *Client) CreateRecordingRuleWriteTarget(body *models.PrometheusRemoteWriteTargetJSON, opts ...ClientOption) (*CreateRecordingRuleWriteTargetOK, error) {
+	params := NewCreateRecordingRuleWriteTargetParams().WithBody(body)
+	return a.CreateRecordingRuleWriteTargetWithParams(params, opts...)
+}
+
+func (a *Client) CreateRecordingRuleWriteTargetWithParams(params *CreateRecordingRuleWriteTargetParams, opts ...ClientOption) (*CreateRecordingRuleWriteTargetOK, error) {
 	if params == nil {
 		params = NewCreateRecordingRuleWriteTargetParams()
 	}
@@ -135,7 +152,12 @@ func (a *Client) CreateRecordingRuleWriteTarget(params *CreateRecordingRuleWrite
 /*
 DeleteRecordingRule deletes removes the rule from the registry and stops it
 */
-func (a *Client) DeleteRecordingRule(params *DeleteRecordingRuleParams, opts ...ClientOption) (*DeleteRecordingRuleOK, error) {
+func (a *Client) DeleteRecordingRule(recordingRuleID int64, opts ...ClientOption) (*DeleteRecordingRuleOK, error) {
+	params := NewDeleteRecordingRuleParams().WithRecordingRuleID(recordingRuleID)
+	return a.DeleteRecordingRuleWithParams(params, opts...)
+}
+
+func (a *Client) DeleteRecordingRuleWithParams(params *DeleteRecordingRuleParams, opts ...ClientOption) (*DeleteRecordingRuleOK, error) {
 	if params == nil {
 		params = NewDeleteRecordingRuleParams()
 	}
@@ -175,7 +197,8 @@ func (a *Client) DeleteRecordingRule(params *DeleteRecordingRuleParams, opts ...
 DeleteRecordingRuleWriteTarget deletes the remote write target
 */
 func (a *Client) DeleteRecordingRuleWriteTarget(opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error) {
-	return a.DeleteRecordingRuleWriteTargetWithParams(nil, opts...)
+	params := NewDeleteRecordingRuleWriteTargetParams()
+	return a.DeleteRecordingRuleWriteTargetWithParams(params, opts...)
 }
 
 func (a *Client) DeleteRecordingRuleWriteTargetWithParams(params *DeleteRecordingRuleWriteTargetParams, opts ...ClientOption) (*DeleteRecordingRuleWriteTargetOK, error) {
@@ -218,7 +241,8 @@ func (a *Client) DeleteRecordingRuleWriteTargetWithParams(params *DeleteRecordin
 GetRecordingRuleWriteTarget returns the prometheus remote write target
 */
 func (a *Client) GetRecordingRuleWriteTarget(opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error) {
-	return a.GetRecordingRuleWriteTargetWithParams(nil, opts...)
+	params := NewGetRecordingRuleWriteTargetParams()
+	return a.GetRecordingRuleWriteTargetWithParams(params, opts...)
 }
 
 func (a *Client) GetRecordingRuleWriteTargetWithParams(params *GetRecordingRuleWriteTargetParams, opts ...ClientOption) (*GetRecordingRuleWriteTargetOK, error) {
@@ -261,7 +285,8 @@ func (a *Client) GetRecordingRuleWriteTargetWithParams(params *GetRecordingRuleW
 ListRecordingRules lists all rules in the database active or deleted
 */
 func (a *Client) ListRecordingRules(opts ...ClientOption) (*ListRecordingRulesOK, error) {
-	return a.ListRecordingRulesWithParams(nil, opts...)
+	params := NewListRecordingRulesParams()
+	return a.ListRecordingRulesWithParams(params, opts...)
 }
 
 func (a *Client) ListRecordingRulesWithParams(params *ListRecordingRulesParams, opts ...ClientOption) (*ListRecordingRulesOK, error) {
@@ -303,7 +328,12 @@ func (a *Client) ListRecordingRulesWithParams(params *ListRecordingRulesParams, 
 /*
 TestCreateRecordingRule tests a recording rule
 */
-func (a *Client) TestCreateRecordingRule(params *TestCreateRecordingRuleParams, opts ...ClientOption) (*TestCreateRecordingRuleOK, error) {
+func (a *Client) TestCreateRecordingRule(body *models.RecordingRuleJSON, opts ...ClientOption) (*TestCreateRecordingRuleOK, error) {
+	params := NewTestCreateRecordingRuleParams().WithBody(body)
+	return a.TestCreateRecordingRuleWithParams(params, opts...)
+}
+
+func (a *Client) TestCreateRecordingRuleWithParams(params *TestCreateRecordingRuleParams, opts ...ClientOption) (*TestCreateRecordingRuleOK, error) {
 	if params == nil {
 		params = NewTestCreateRecordingRuleParams()
 	}
@@ -342,7 +372,12 @@ func (a *Client) TestCreateRecordingRule(params *TestCreateRecordingRuleParams, 
 /*
 UpdateRecordingRule updates the active status of a rule
 */
-func (a *Client) UpdateRecordingRule(params *UpdateRecordingRuleParams, opts ...ClientOption) (*UpdateRecordingRuleOK, error) {
+func (a *Client) UpdateRecordingRule(body *models.RecordingRuleJSON, opts ...ClientOption) (*UpdateRecordingRuleOK, error) {
+	params := NewUpdateRecordingRuleParams().WithBody(body)
+	return a.UpdateRecordingRuleWithParams(params, opts...)
+}
+
+func (a *Client) UpdateRecordingRuleWithParams(params *UpdateRecordingRuleParams, opts ...ClientOption) (*UpdateRecordingRuleOK, error) {
 	if params == nil {
 		params = NewUpdateRecordingRuleParams()
 	}

--- a/client/reports/reports_client.go
+++ b/client/reports/reports_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new reports API client.
@@ -30,11 +32,14 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateReport(params *CreateReportParams, opts ...ClientOption) (*CreateReportOK, error)
+	CreateReport(body *models.CreateOrUpdateConfigCmd, opts ...ClientOption) (*CreateReportOK, error)
+	CreateReportWithParams(params *CreateReportParams, opts ...ClientOption) (*CreateReportOK, error)
 
-	DeleteReport(params *DeleteReportParams, opts ...ClientOption) (*DeleteReportOK, error)
+	DeleteReport(id int64, opts ...ClientOption) (*DeleteReportOK, error)
+	DeleteReportWithParams(params *DeleteReportParams, opts ...ClientOption) (*DeleteReportOK, error)
 
-	GetReport(params *GetReportParams, opts ...ClientOption) (*GetReportOK, error)
+	GetReport(id int64, opts ...ClientOption) (*GetReportOK, error)
+	GetReportWithParams(params *GetReportParams, opts ...ClientOption) (*GetReportOK, error)
 
 	GetReportSettings(opts ...ClientOption) (*GetReportSettingsOK, error)
 	GetReportSettingsWithParams(params *GetReportSettingsParams, opts ...ClientOption) (*GetReportSettingsOK, error)
@@ -46,25 +51,34 @@ type ClientService interface {
 
 	RenderReportPDFs(params *RenderReportPDFsParams, opts ...ClientOption) (*RenderReportPDFsOK, error)
 
-	SaveReportSettings(params *SaveReportSettingsParams, opts ...ClientOption) (*SaveReportSettingsOK, error)
+	SaveReportSettings(body *models.SettingsDTO, opts ...ClientOption) (*SaveReportSettingsOK, error)
+	SaveReportSettingsWithParams(params *SaveReportSettingsParams, opts ...ClientOption) (*SaveReportSettingsOK, error)
 
-	SendReport(params *SendReportParams, opts ...ClientOption) (*SendReportOK, error)
+	SendReport(body *models.ReportEmailDTO, opts ...ClientOption) (*SendReportOK, error)
+	SendReportWithParams(params *SendReportParams, opts ...ClientOption) (*SendReportOK, error)
 
-	SendTestEmail(params *SendTestEmailParams, opts ...ClientOption) (*SendTestEmailOK, error)
+	SendTestEmail(body *models.CreateOrUpdateConfigCmd, opts ...ClientOption) (*SendTestEmailOK, error)
+	SendTestEmailWithParams(params *SendTestEmailParams, opts ...ClientOption) (*SendTestEmailOK, error)
 
-	UpdateReport(params *UpdateReportParams, opts ...ClientOption) (*UpdateReportOK, error)
+	UpdateReport(id int64, body *models.CreateOrUpdateConfigCmd, opts ...ClientOption) (*UpdateReportOK, error)
+	UpdateReportWithParams(params *UpdateReportParams, opts ...ClientOption) (*UpdateReportOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
 
 /*
-	CreateReport creates a report
+CreateReport creates a report
 
-	Available to org admins only and with a valid license.
+Available to org admins only and with a valid license.
 
 You need to have a permission with action `reports.admin:create`.
 */
-func (a *Client) CreateReport(params *CreateReportParams, opts ...ClientOption) (*CreateReportOK, error) {
+func (a *Client) CreateReport(body *models.CreateOrUpdateConfigCmd, opts ...ClientOption) (*CreateReportOK, error) {
+	params := NewCreateReportParams().WithBody(body)
+	return a.CreateReportWithParams(params, opts...)
+}
+
+func (a *Client) CreateReportWithParams(params *CreateReportParams, opts ...ClientOption) (*CreateReportOK, error) {
 	if params == nil {
 		params = NewCreateReportParams()
 	}
@@ -101,13 +115,18 @@ func (a *Client) CreateReport(params *CreateReportParams, opts ...ClientOption) 
 }
 
 /*
-	DeleteReport deletes a report
+DeleteReport deletes a report
 
-	Available to org admins only and with a valid or expired license.
+Available to org admins only and with a valid or expired license.
 
 You need to have a permission with action `reports.delete` with scope `reports:id:<report ID>`.
 */
-func (a *Client) DeleteReport(params *DeleteReportParams, opts ...ClientOption) (*DeleteReportOK, error) {
+func (a *Client) DeleteReport(id int64, opts ...ClientOption) (*DeleteReportOK, error) {
+	params := NewDeleteReportParams().WithID(id)
+	return a.DeleteReportWithParams(params, opts...)
+}
+
+func (a *Client) DeleteReportWithParams(params *DeleteReportParams, opts ...ClientOption) (*DeleteReportOK, error) {
 	if params == nil {
 		params = NewDeleteReportParams()
 	}
@@ -144,13 +163,18 @@ func (a *Client) DeleteReport(params *DeleteReportParams, opts ...ClientOption) 
 }
 
 /*
-	GetReport gets a report
+GetReport gets a report
 
-	Available to org admins only and with a valid or expired license.
+Available to org admins only and with a valid or expired license.
 
 You need to have a permission with action `reports:read` with scope `reports:id:<report ID>`.
 */
-func (a *Client) GetReport(params *GetReportParams, opts ...ClientOption) (*GetReportOK, error) {
+func (a *Client) GetReport(id int64, opts ...ClientOption) (*GetReportOK, error) {
+	params := NewGetReportParams().WithID(id)
+	return a.GetReportWithParams(params, opts...)
+}
+
+func (a *Client) GetReportWithParams(params *GetReportParams, opts ...ClientOption) (*GetReportOK, error) {
 	if params == nil {
 		params = NewGetReportParams()
 	}
@@ -187,14 +211,15 @@ func (a *Client) GetReport(params *GetReportParams, opts ...ClientOption) (*GetR
 }
 
 /*
-	GetReportSettings gets settings
+GetReportSettings gets settings
 
-	Available to org admins only and with a valid or expired license.
+Available to org admins only and with a valid or expired license.
 
 You need to have a permission with action `reports.settings:read`x.
 */
 func (a *Client) GetReportSettings(opts ...ClientOption) (*GetReportSettingsOK, error) {
-	return a.GetReportSettingsWithParams(nil, opts...)
+	params := NewGetReportSettingsParams()
+	return a.GetReportSettingsWithParams(params, opts...)
 }
 
 func (a *Client) GetReportSettingsWithParams(params *GetReportSettingsParams, opts ...ClientOption) (*GetReportSettingsOK, error) {
@@ -234,14 +259,15 @@ func (a *Client) GetReportSettingsWithParams(params *GetReportSettingsParams, op
 }
 
 /*
-	GetReports lists reports
+GetReports lists reports
 
-	Available to org admins only and with a valid or expired license.
+Available to org admins only and with a valid or expired license.
 
 You need to have a permission with action `reports:read` with scope `reports:*`.
 */
 func (a *Client) GetReports(opts ...ClientOption) (*GetReportsOK, error) {
-	return a.GetReportsWithParams(nil, opts...)
+	params := NewGetReportsParams()
+	return a.GetReportsWithParams(params, opts...)
 }
 
 func (a *Client) GetReportsWithParams(params *GetReportsParams, opts ...ClientOption) (*GetReportsOK, error) {
@@ -285,6 +311,7 @@ RenderReportPDF renders report for dashboard
 
 Please refer to [reports enterprise](#/reports/renderReportPDFs) instead. This will be removed in Grafana 10.
 */
+
 func (a *Client) RenderReportPDF(params *RenderReportPDFParams, opts ...ClientOption) (*RenderReportPDFOK, error) {
 	if params == nil {
 		params = NewRenderReportPDFParams()
@@ -326,6 +353,7 @@ RenderReportPDFs renders report for multiple dashboards
 
 Available to all users and with a valid license.
 */
+
 func (a *Client) RenderReportPDFs(params *RenderReportPDFsParams, opts ...ClientOption) (*RenderReportPDFsOK, error) {
 	if params == nil {
 		params = NewRenderReportPDFsParams()
@@ -363,13 +391,18 @@ func (a *Client) RenderReportPDFs(params *RenderReportPDFsParams, opts ...Client
 }
 
 /*
-	SaveReportSettings saves settings
+SaveReportSettings saves settings
 
-	Available to org admins only and with a valid or expired license.
+Available to org admins only and with a valid or expired license.
 
 You need to have a permission with action `reports.settings:write`xx.
 */
-func (a *Client) SaveReportSettings(params *SaveReportSettingsParams, opts ...ClientOption) (*SaveReportSettingsOK, error) {
+func (a *Client) SaveReportSettings(body *models.SettingsDTO, opts ...ClientOption) (*SaveReportSettingsOK, error) {
+	params := NewSaveReportSettingsParams().WithBody(body)
+	return a.SaveReportSettingsWithParams(params, opts...)
+}
+
+func (a *Client) SaveReportSettingsWithParams(params *SaveReportSettingsParams, opts ...ClientOption) (*SaveReportSettingsOK, error) {
 	if params == nil {
 		params = NewSaveReportSettingsParams()
 	}
@@ -406,16 +439,21 @@ func (a *Client) SaveReportSettings(params *SaveReportSettingsParams, opts ...Cl
 }
 
 /*
-	SendReport sends a report
+SendReport sends a report
 
-	Generate and send a report. This API waits for the report to be generated before returning. We recommend that you set the client’s timeout to at least 60 seconds. Available to org admins only and with a valid license.
+Generate and send a report. This API waits for the report to be generated before returning. We recommend that you set the client’s timeout to at least 60 seconds. Available to org admins only and with a valid license.
 
 Only available in Grafana Enterprise v7.0+.
 This API endpoint is experimental and may be deprecated in a future release. On deprecation, a migration strategy will be provided and the endpoint will remain functional until the next major release of Grafana.
 
 You need to have a permission with action `reports:send`.
 */
-func (a *Client) SendReport(params *SendReportParams, opts ...ClientOption) (*SendReportOK, error) {
+func (a *Client) SendReport(body *models.ReportEmailDTO, opts ...ClientOption) (*SendReportOK, error) {
+	params := NewSendReportParams().WithBody(body)
+	return a.SendReportWithParams(params, opts...)
+}
+
+func (a *Client) SendReportWithParams(params *SendReportParams, opts ...ClientOption) (*SendReportOK, error) {
 	if params == nil {
 		params = NewSendReportParams()
 	}
@@ -452,13 +490,18 @@ func (a *Client) SendReport(params *SendReportParams, opts ...ClientOption) (*Se
 }
 
 /*
-	SendTestEmail sends test report via email
+SendTestEmail sends test report via email
 
-	Available to org admins only and with a valid license.
+Available to org admins only and with a valid license.
 
 You need to have a permission with action `reports:send`.
 */
-func (a *Client) SendTestEmail(params *SendTestEmailParams, opts ...ClientOption) (*SendTestEmailOK, error) {
+func (a *Client) SendTestEmail(body *models.CreateOrUpdateConfigCmd, opts ...ClientOption) (*SendTestEmailOK, error) {
+	params := NewSendTestEmailParams().WithBody(body)
+	return a.SendTestEmailWithParams(params, opts...)
+}
+
+func (a *Client) SendTestEmailWithParams(params *SendTestEmailParams, opts ...ClientOption) (*SendTestEmailOK, error) {
 	if params == nil {
 		params = NewSendTestEmailParams()
 	}
@@ -495,13 +538,18 @@ func (a *Client) SendTestEmail(params *SendTestEmailParams, opts ...ClientOption
 }
 
 /*
-	UpdateReport updates a report
+UpdateReport updates a report
 
-	Available to org admins only and with a valid or expired license.
+Available to org admins only and with a valid or expired license.
 
 You need to have a permission with action `reports.admin:write` with scope `reports:id:<report ID>`.
 */
-func (a *Client) UpdateReport(params *UpdateReportParams, opts ...ClientOption) (*UpdateReportOK, error) {
+func (a *Client) UpdateReport(id int64, body *models.CreateOrUpdateConfigCmd, opts ...ClientOption) (*UpdateReportOK, error) {
+	params := NewUpdateReportParams().WithBody(body).WithID(id)
+	return a.UpdateReportWithParams(params, opts...)
+}
+
+func (a *Client) UpdateReportWithParams(params *UpdateReportParams, opts ...ClientOption) (*UpdateReportOK, error) {
 	if params == nil {
 		params = NewUpdateReportParams()
 	}

--- a/client/saml/saml_client.go
+++ b/client/saml/saml_client.go
@@ -50,7 +50,8 @@ type ClientService interface {
 GetMetadata its exposes the s p grafana s metadata for the Id p s consumption
 */
 func (a *Client) GetMetadata(opts ...ClientOption) (*GetMetadataOK, error) {
-	return a.GetMetadataWithParams(nil, opts...)
+	params := NewGetMetadataParams()
+	return a.GetMetadataWithParams(params, opts...)
 }
 
 func (a *Client) GetMetadataWithParams(params *GetMetadataParams, opts ...ClientOption) (*GetMetadataOK, error) {
@@ -93,7 +94,8 @@ func (a *Client) GetMetadataWithParams(params *GetMetadataParams, opts ...Client
 GetSAMLLogout gets logout initiates single logout process
 */
 func (a *Client) GetSAMLLogout(opts ...ClientOption) error {
-	return a.GetSAMLLogoutWithParams(nil, opts...)
+	params := NewGetSAMLLogoutParams()
+	return a.GetSAMLLogoutWithParams(params, opts...)
 }
 
 func (a *Client) GetSAMLLogoutWithParams(params *GetSAMLLogoutParams, opts ...ClientOption) error {
@@ -126,16 +128,16 @@ func (a *Client) GetSAMLLogoutWithParams(params *GetSAMLLogoutParams, opts ...Cl
 }
 
 /*
-	GetSLO its performs single logout s l o callback
+GetSLO its performs single logout s l o callback
 
-	There might be two possible requests:
-
+There might be two possible requests:
 1. Logout response (callback) when Grafana initiates single logout and IdP returns response to logout request.
 2. Logout request when another SP initiates single logout and IdP sends logout request to the Grafana,
 or in case of IdP-initiated logout.
 */
 func (a *Client) GetSLO(opts ...ClientOption) error {
-	return a.GetSLOWithParams(nil, opts...)
+	params := NewGetSLOParams()
+	return a.GetSLOWithParams(params, opts...)
 }
 
 func (a *Client) GetSLOWithParams(params *GetSLOParams, opts ...ClientOption) error {
@@ -170,6 +172,7 @@ func (a *Client) GetSLOWithParams(params *GetSLOParams, opts ...ClientOption) er
 /*
 PostACS its performs assertion consumer service a c s
 */
+
 func (a *Client) PostACS(params *PostACSParams, opts ...ClientOption) error {
 	if params == nil {
 		params = NewPostACSParams()
@@ -200,14 +203,14 @@ func (a *Client) PostACS(params *PostACSParams, opts ...ClientOption) error {
 }
 
 /*
-	PostSLO its performs single logout s l o callback
+PostSLO its performs single logout s l o callback
 
-	There might be two possible requests:
-
+There might be two possible requests:
 1. Logout response (callback) when Grafana initiates single logout and IdP returns response to logout request.
 2. Logout request when another SP initiates single logout and IdP sends logout request to the Grafana,
 or in case of IdP-initiated logout.
 */
+
 func (a *Client) PostSLO(params *PostSLOParams, opts ...ClientOption) error {
 	if params == nil {
 		params = NewPostSLOParams()

--- a/client/search/search_client.go
+++ b/client/search/search_client.go
@@ -42,7 +42,8 @@ type ClientService interface {
 ListSortOptions lists search sorting options
 */
 func (a *Client) ListSortOptions(opts ...ClientOption) (*ListSortOptionsOK, error) {
-	return a.ListSortOptionsWithParams(nil, opts...)
+	params := NewListSortOptionsParams()
+	return a.ListSortOptionsWithParams(params, opts...)
 }
 
 func (a *Client) ListSortOptionsWithParams(params *ListSortOptionsParams, opts ...ClientOption) (*ListSortOptionsOK, error) {
@@ -84,6 +85,7 @@ func (a *Client) ListSortOptionsWithParams(params *ListSortOptionsParams, opts .
 /*
 Search search API
 */
+
 func (a *Client) Search(params *SearchParams, opts ...ClientOption) (*SearchOK, error) {
 	if params == nil {
 		params = NewSearchParams()

--- a/client/service_accounts/service_accounts_client.go
+++ b/client/service_accounts/service_accounts_client.go
@@ -34,13 +34,17 @@ type ClientService interface {
 
 	CreateToken(params *CreateTokenParams, opts ...ClientOption) (*CreateTokenOK, error)
 
-	DeleteServiceAccount(params *DeleteServiceAccountParams, opts ...ClientOption) (*DeleteServiceAccountOK, error)
+	DeleteServiceAccount(serviceAccountID int64, opts ...ClientOption) (*DeleteServiceAccountOK, error)
+	DeleteServiceAccountWithParams(params *DeleteServiceAccountParams, opts ...ClientOption) (*DeleteServiceAccountOK, error)
 
-	DeleteToken(params *DeleteTokenParams, opts ...ClientOption) (*DeleteTokenOK, error)
+	DeleteToken(tokenID int64, serviceAccountID int64, opts ...ClientOption) (*DeleteTokenOK, error)
+	DeleteTokenWithParams(params *DeleteTokenParams, opts ...ClientOption) (*DeleteTokenOK, error)
 
-	ListTokens(params *ListTokensParams, opts ...ClientOption) (*ListTokensOK, error)
+	ListTokens(serviceAccountID int64, opts ...ClientOption) (*ListTokensOK, error)
+	ListTokensWithParams(params *ListTokensParams, opts ...ClientOption) (*ListTokensOK, error)
 
-	RetrieveServiceAccount(params *RetrieveServiceAccountParams, opts ...ClientOption) (*RetrieveServiceAccountOK, error)
+	RetrieveServiceAccount(serviceAccountID int64, opts ...ClientOption) (*RetrieveServiceAccountOK, error)
+	RetrieveServiceAccountWithParams(params *RetrieveServiceAccountParams, opts ...ClientOption) (*RetrieveServiceAccountOK, error)
 
 	SearchOrgServiceAccountsWithPaging(params *SearchOrgServiceAccountsWithPagingParams, opts ...ClientOption) (*SearchOrgServiceAccountsWithPagingOK, error)
 
@@ -50,14 +54,14 @@ type ClientService interface {
 }
 
 /*
-	CreateServiceAccount creates service account
+CreateServiceAccount creates service account
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:write` scope: `serviceaccounts:*`
 
 Requires basic authentication and that the authenticated user is a Grafana Admin.
 */
+
 func (a *Client) CreateServiceAccount(params *CreateServiceAccountParams, opts ...ClientOption) (*CreateServiceAccountCreated, error) {
 	if params == nil {
 		params = NewCreateServiceAccountParams()
@@ -95,12 +99,12 @@ func (a *Client) CreateServiceAccount(params *CreateServiceAccountParams, opts .
 }
 
 /*
-	CreateToken creates new token adds a token to a service account
+CreateToken creates new token adds a token to a service account
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:write` scope: `serviceaccounts:id:1` (single service account)
 */
+
 func (a *Client) CreateToken(params *CreateTokenParams, opts ...ClientOption) (*CreateTokenOK, error) {
 	if params == nil {
 		params = NewCreateTokenParams()
@@ -138,13 +142,17 @@ func (a *Client) CreateToken(params *CreateTokenParams, opts ...ClientOption) (*
 }
 
 /*
-	DeleteServiceAccount deletes service account
+DeleteServiceAccount deletes service account
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:delete` scope: `serviceaccounts:id:1` (single service account)
 */
-func (a *Client) DeleteServiceAccount(params *DeleteServiceAccountParams, opts ...ClientOption) (*DeleteServiceAccountOK, error) {
+func (a *Client) DeleteServiceAccount(serviceAccountID int64, opts ...ClientOption) (*DeleteServiceAccountOK, error) {
+	params := NewDeleteServiceAccountParams().WithServiceAccountID(serviceAccountID)
+	return a.DeleteServiceAccountWithParams(params, opts...)
+}
+
+func (a *Client) DeleteServiceAccountWithParams(params *DeleteServiceAccountParams, opts ...ClientOption) (*DeleteServiceAccountOK, error) {
 	if params == nil {
 		params = NewDeleteServiceAccountParams()
 	}
@@ -181,15 +189,19 @@ func (a *Client) DeleteServiceAccount(params *DeleteServiceAccountParams, opts .
 }
 
 /*
-	DeleteToken deletes token deletes service account tokens
+DeleteToken deletes token deletes service account tokens
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:write` scope: `serviceaccounts:id:1` (single service account)
 
 Requires basic authentication and that the authenticated user is a Grafana Admin.
 */
-func (a *Client) DeleteToken(params *DeleteTokenParams, opts ...ClientOption) (*DeleteTokenOK, error) {
+func (a *Client) DeleteToken(tokenID int64, serviceAccountID int64, opts ...ClientOption) (*DeleteTokenOK, error) {
+	params := NewDeleteTokenParams().WithServiceAccountID(serviceAccountID).WithTokenID(tokenID)
+	return a.DeleteTokenWithParams(params, opts...)
+}
+
+func (a *Client) DeleteTokenWithParams(params *DeleteTokenParams, opts ...ClientOption) (*DeleteTokenOK, error) {
 	if params == nil {
 		params = NewDeleteTokenParams()
 	}
@@ -226,15 +238,19 @@ func (a *Client) DeleteToken(params *DeleteTokenParams, opts ...ClientOption) (*
 }
 
 /*
-	ListTokens gets service account tokens
+ListTokens gets service account tokens
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:read` scope: `global:serviceaccounts:id:1` (single service account)
 
 Requires basic authentication and that the authenticated user is a Grafana Admin.
 */
-func (a *Client) ListTokens(params *ListTokensParams, opts ...ClientOption) (*ListTokensOK, error) {
+func (a *Client) ListTokens(serviceAccountID int64, opts ...ClientOption) (*ListTokensOK, error) {
+	params := NewListTokensParams().WithServiceAccountID(serviceAccountID)
+	return a.ListTokensWithParams(params, opts...)
+}
+
+func (a *Client) ListTokensWithParams(params *ListTokensParams, opts ...ClientOption) (*ListTokensOK, error) {
 	if params == nil {
 		params = NewListTokensParams()
 	}
@@ -271,13 +287,17 @@ func (a *Client) ListTokens(params *ListTokensParams, opts ...ClientOption) (*Li
 }
 
 /*
-	RetrieveServiceAccount gets single serviceaccount by Id
+RetrieveServiceAccount gets single serviceaccount by Id
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:read` scope: `serviceaccounts:id:1` (single service account)
 */
-func (a *Client) RetrieveServiceAccount(params *RetrieveServiceAccountParams, opts ...ClientOption) (*RetrieveServiceAccountOK, error) {
+func (a *Client) RetrieveServiceAccount(serviceAccountID int64, opts ...ClientOption) (*RetrieveServiceAccountOK, error) {
+	params := NewRetrieveServiceAccountParams().WithServiceAccountID(serviceAccountID)
+	return a.RetrieveServiceAccountWithParams(params, opts...)
+}
+
+func (a *Client) RetrieveServiceAccountWithParams(params *RetrieveServiceAccountParams, opts ...ClientOption) (*RetrieveServiceAccountOK, error) {
 	if params == nil {
 		params = NewRetrieveServiceAccountParams()
 	}
@@ -314,12 +334,12 @@ func (a *Client) RetrieveServiceAccount(params *RetrieveServiceAccountParams, op
 }
 
 /*
-	SearchOrgServiceAccountsWithPaging searches service accounts with paging
+SearchOrgServiceAccountsWithPaging searches service accounts with paging
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:read` scope: `serviceaccounts:*`
 */
+
 func (a *Client) SearchOrgServiceAccountsWithPaging(params *SearchOrgServiceAccountsWithPagingParams, opts ...ClientOption) (*SearchOrgServiceAccountsWithPagingOK, error) {
 	if params == nil {
 		params = NewSearchOrgServiceAccountsWithPagingParams()
@@ -357,12 +377,12 @@ func (a *Client) SearchOrgServiceAccountsWithPaging(params *SearchOrgServiceAcco
 }
 
 /*
-	UpdateServiceAccount updates service account
+UpdateServiceAccount updates service account
 
-	Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
-
+Required permissions (See note in the [introduction](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api) for an explanation):
 action: `serviceaccounts:write` scope: `serviceaccounts:id:1` (single service account)
 */
+
 func (a *Client) UpdateServiceAccount(params *UpdateServiceAccountParams, opts ...ClientOption) (*UpdateServiceAccountOK, error) {
 	if params == nil {
 		params = NewUpdateServiceAccountParams()

--- a/client/signed_in_user/signed_in_user_client.go
+++ b/client/signed_in_user/signed_in_user_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new signed in user API client.
@@ -30,7 +32,8 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	ChangeUserPassword(params *ChangeUserPasswordParams, opts ...ClientOption) (*ChangeUserPasswordOK, error)
+	ChangeUserPassword(body *models.ChangeUserPasswordCommand, opts ...ClientOption) (*ChangeUserPasswordOK, error)
+	ChangeUserPasswordWithParams(params *ChangeUserPasswordParams, opts ...ClientOption) (*ChangeUserPasswordOK, error)
 
 	ClearHelpFlags(opts ...ClientOption) (*ClearHelpFlagsOK, error)
 	ClearHelpFlagsWithParams(params *ClearHelpFlagsParams, opts ...ClientOption) (*ClearHelpFlagsOK, error)
@@ -50,21 +53,29 @@ type ClientService interface {
 	GetUserQuotas(opts ...ClientOption) (*GetUserQuotasOK, error)
 	GetUserQuotasWithParams(params *GetUserQuotasParams, opts ...ClientOption) (*GetUserQuotasOK, error)
 
-	RevokeUserAuthToken(params *RevokeUserAuthTokenParams, opts ...ClientOption) (*RevokeUserAuthTokenOK, error)
+	RevokeUserAuthToken(body *models.RevokeAuthTokenCmd, opts ...ClientOption) (*RevokeUserAuthTokenOK, error)
+	RevokeUserAuthTokenWithParams(params *RevokeUserAuthTokenParams, opts ...ClientOption) (*RevokeUserAuthTokenOK, error)
 
-	SetHelpFlag(params *SetHelpFlagParams, opts ...ClientOption) (*SetHelpFlagOK, error)
+	SetHelpFlag(flagID string, opts ...ClientOption) (*SetHelpFlagOK, error)
+	SetHelpFlagWithParams(params *SetHelpFlagParams, opts ...ClientOption) (*SetHelpFlagOK, error)
 
-	StarDashboard(params *StarDashboardParams, opts ...ClientOption) (*StarDashboardOK, error)
+	StarDashboard(dashboardID string, opts ...ClientOption) (*StarDashboardOK, error)
+	StarDashboardWithParams(params *StarDashboardParams, opts ...ClientOption) (*StarDashboardOK, error)
 
-	StarDashboardByUID(params *StarDashboardByUIDParams, opts ...ClientOption) (*StarDashboardByUIDOK, error)
+	StarDashboardByUID(dashboardUID string, opts ...ClientOption) (*StarDashboardByUIDOK, error)
+	StarDashboardByUIDWithParams(params *StarDashboardByUIDParams, opts ...ClientOption) (*StarDashboardByUIDOK, error)
 
-	UnstarDashboard(params *UnstarDashboardParams, opts ...ClientOption) (*UnstarDashboardOK, error)
+	UnstarDashboard(dashboardID string, opts ...ClientOption) (*UnstarDashboardOK, error)
+	UnstarDashboardWithParams(params *UnstarDashboardParams, opts ...ClientOption) (*UnstarDashboardOK, error)
 
-	UnstarDashboardByUID(params *UnstarDashboardByUIDParams, opts ...ClientOption) (*UnstarDashboardByUIDOK, error)
+	UnstarDashboardByUID(dashboardUID string, opts ...ClientOption) (*UnstarDashboardByUIDOK, error)
+	UnstarDashboardByUIDWithParams(params *UnstarDashboardByUIDParams, opts ...ClientOption) (*UnstarDashboardByUIDOK, error)
 
-	UpdateSignedInUser(params *UpdateSignedInUserParams, opts ...ClientOption) (*UpdateSignedInUserOK, error)
+	UpdateSignedInUser(body *models.UpdateUserCommand, opts ...ClientOption) (*UpdateSignedInUserOK, error)
+	UpdateSignedInUserWithParams(params *UpdateSignedInUserParams, opts ...ClientOption) (*UpdateSignedInUserOK, error)
 
-	UserSetUsingOrg(params *UserSetUsingOrgParams, opts ...ClientOption) (*UserSetUsingOrgOK, error)
+	UserSetUsingOrg(orgID int64, opts ...ClientOption) (*UserSetUsingOrgOK, error)
+	UserSetUsingOrgWithParams(params *UserSetUsingOrgParams, opts ...ClientOption) (*UserSetUsingOrgOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -74,7 +85,12 @@ ChangeUserPassword changes password
 
 Changes the password for the user.
 */
-func (a *Client) ChangeUserPassword(params *ChangeUserPasswordParams, opts ...ClientOption) (*ChangeUserPasswordOK, error) {
+func (a *Client) ChangeUserPassword(body *models.ChangeUserPasswordCommand, opts ...ClientOption) (*ChangeUserPasswordOK, error) {
+	params := NewChangeUserPasswordParams().WithBody(body)
+	return a.ChangeUserPasswordWithParams(params, opts...)
+}
+
+func (a *Client) ChangeUserPasswordWithParams(params *ChangeUserPasswordParams, opts ...ClientOption) (*ChangeUserPasswordOK, error) {
 	if params == nil {
 		params = NewChangeUserPasswordParams()
 	}
@@ -114,7 +130,8 @@ func (a *Client) ChangeUserPassword(params *ChangeUserPasswordParams, opts ...Cl
 ClearHelpFlags clears user help flag
 */
 func (a *Client) ClearHelpFlags(opts ...ClientOption) (*ClearHelpFlagsOK, error) {
-	return a.ClearHelpFlagsWithParams(nil, opts...)
+	params := NewClearHelpFlagsParams()
+	return a.ClearHelpFlagsWithParams(params, opts...)
 }
 
 func (a *Client) ClearHelpFlagsWithParams(params *ClearHelpFlagsParams, opts ...ClientOption) (*ClearHelpFlagsOK, error) {
@@ -157,7 +174,8 @@ func (a *Client) ClearHelpFlagsWithParams(params *ClearHelpFlagsParams, opts ...
 GetSignedInUser Get (current authenticated user)
 */
 func (a *Client) GetSignedInUser(opts ...ClientOption) (*GetSignedInUserOK, error) {
-	return a.GetSignedInUserWithParams(nil, opts...)
+	params := NewGetSignedInUserParams()
+	return a.GetSignedInUserWithParams(params, opts...)
 }
 
 func (a *Client) GetSignedInUserWithParams(params *GetSignedInUserParams, opts ...ClientOption) (*GetSignedInUserOK, error) {
@@ -202,7 +220,8 @@ GetSignedInUserOrgList organizations of the actual user
 Return a list of all organizations of the current user.
 */
 func (a *Client) GetSignedInUserOrgList(opts ...ClientOption) (*GetSignedInUserOrgListOK, error) {
-	return a.GetSignedInUserOrgListWithParams(nil, opts...)
+	params := NewGetSignedInUserOrgListParams()
+	return a.GetSignedInUserOrgListWithParams(params, opts...)
 }
 
 func (a *Client) GetSignedInUserOrgListWithParams(params *GetSignedInUserOrgListParams, opts ...ClientOption) (*GetSignedInUserOrgListOK, error) {
@@ -247,7 +266,8 @@ GetSignedInUserTeamList teams that the actual user is member of
 Return a list of all teams that the current user is member of.
 */
 func (a *Client) GetSignedInUserTeamList(opts ...ClientOption) (*GetSignedInUserTeamListOK, error) {
-	return a.GetSignedInUserTeamListWithParams(nil, opts...)
+	params := NewGetSignedInUserTeamListParams()
+	return a.GetSignedInUserTeamListWithParams(params, opts...)
 }
 
 func (a *Client) GetSignedInUserTeamListWithParams(params *GetSignedInUserTeamListParams, opts ...ClientOption) (*GetSignedInUserTeamListOK, error) {
@@ -292,7 +312,8 @@ GetUserAuthTokens auths tokens of the actual user
 Return a list of all auth tokens (devices) that the actual user currently have logged in from.
 */
 func (a *Client) GetUserAuthTokens(opts ...ClientOption) (*GetUserAuthTokensOK, error) {
-	return a.GetUserAuthTokensWithParams(nil, opts...)
+	params := NewGetUserAuthTokensParams()
+	return a.GetUserAuthTokensWithParams(params, opts...)
 }
 
 func (a *Client) GetUserAuthTokensWithParams(params *GetUserAuthTokensParams, opts ...ClientOption) (*GetUserAuthTokensOK, error) {
@@ -335,7 +356,8 @@ func (a *Client) GetUserAuthTokensWithParams(params *GetUserAuthTokensParams, op
 GetUserQuotas fetches user quota
 */
 func (a *Client) GetUserQuotas(opts ...ClientOption) (*GetUserQuotasOK, error) {
-	return a.GetUserQuotasWithParams(nil, opts...)
+	params := NewGetUserQuotasParams()
+	return a.GetUserQuotasWithParams(params, opts...)
 }
 
 func (a *Client) GetUserQuotasWithParams(params *GetUserQuotasParams, opts ...ClientOption) (*GetUserQuotasOK, error) {
@@ -379,7 +401,12 @@ RevokeUserAuthToken revokes an auth token of the actual user
 
 Revokes the given auth token (device) for the actual user. User of issued auth token (device) will no longer be logged in and will be required to authenticate again upon next activity.
 */
-func (a *Client) RevokeUserAuthToken(params *RevokeUserAuthTokenParams, opts ...ClientOption) (*RevokeUserAuthTokenOK, error) {
+func (a *Client) RevokeUserAuthToken(body *models.RevokeAuthTokenCmd, opts ...ClientOption) (*RevokeUserAuthTokenOK, error) {
+	params := NewRevokeUserAuthTokenParams().WithBody(body)
+	return a.RevokeUserAuthTokenWithParams(params, opts...)
+}
+
+func (a *Client) RevokeUserAuthTokenWithParams(params *RevokeUserAuthTokenParams, opts ...ClientOption) (*RevokeUserAuthTokenOK, error) {
 	if params == nil {
 		params = NewRevokeUserAuthTokenParams()
 	}
@@ -418,7 +445,12 @@ func (a *Client) RevokeUserAuthToken(params *RevokeUserAuthTokenParams, opts ...
 /*
 SetHelpFlag sets user help flag
 */
-func (a *Client) SetHelpFlag(params *SetHelpFlagParams, opts ...ClientOption) (*SetHelpFlagOK, error) {
+func (a *Client) SetHelpFlag(flagID string, opts ...ClientOption) (*SetHelpFlagOK, error) {
+	params := NewSetHelpFlagParams().WithFlagID(flagID)
+	return a.SetHelpFlagWithParams(params, opts...)
+}
+
+func (a *Client) SetHelpFlagWithParams(params *SetHelpFlagParams, opts ...ClientOption) (*SetHelpFlagOK, error) {
 	if params == nil {
 		params = NewSetHelpFlagParams()
 	}
@@ -459,7 +491,12 @@ StarDashboard stars a dashboard
 
 Stars the given Dashboard for the actual user.
 */
-func (a *Client) StarDashboard(params *StarDashboardParams, opts ...ClientOption) (*StarDashboardOK, error) {
+func (a *Client) StarDashboard(dashboardID string, opts ...ClientOption) (*StarDashboardOK, error) {
+	params := NewStarDashboardParams().WithDashboardID(dashboardID)
+	return a.StarDashboardWithParams(params, opts...)
+}
+
+func (a *Client) StarDashboardWithParams(params *StarDashboardParams, opts ...ClientOption) (*StarDashboardOK, error) {
 	if params == nil {
 		params = NewStarDashboardParams()
 	}
@@ -500,7 +537,12 @@ StarDashboardByUID stars a dashboard
 
 Stars the given Dashboard for the actual user.
 */
-func (a *Client) StarDashboardByUID(params *StarDashboardByUIDParams, opts ...ClientOption) (*StarDashboardByUIDOK, error) {
+func (a *Client) StarDashboardByUID(dashboardUID string, opts ...ClientOption) (*StarDashboardByUIDOK, error) {
+	params := NewStarDashboardByUIDParams().WithDashboardUID(dashboardUID)
+	return a.StarDashboardByUIDWithParams(params, opts...)
+}
+
+func (a *Client) StarDashboardByUIDWithParams(params *StarDashboardByUIDParams, opts ...ClientOption) (*StarDashboardByUIDOK, error) {
 	if params == nil {
 		params = NewStarDashboardByUIDParams()
 	}
@@ -541,7 +583,12 @@ UnstarDashboard unstars a dashboard
 
 Deletes the starring of the given Dashboard for the actual user.
 */
-func (a *Client) UnstarDashboard(params *UnstarDashboardParams, opts ...ClientOption) (*UnstarDashboardOK, error) {
+func (a *Client) UnstarDashboard(dashboardID string, opts ...ClientOption) (*UnstarDashboardOK, error) {
+	params := NewUnstarDashboardParams().WithDashboardID(dashboardID)
+	return a.UnstarDashboardWithParams(params, opts...)
+}
+
+func (a *Client) UnstarDashboardWithParams(params *UnstarDashboardParams, opts ...ClientOption) (*UnstarDashboardOK, error) {
 	if params == nil {
 		params = NewUnstarDashboardParams()
 	}
@@ -582,7 +629,12 @@ UnstarDashboardByUID unstars a dashboard
 
 Deletes the starring of the given Dashboard for the actual user.
 */
-func (a *Client) UnstarDashboardByUID(params *UnstarDashboardByUIDParams, opts ...ClientOption) (*UnstarDashboardByUIDOK, error) {
+func (a *Client) UnstarDashboardByUID(dashboardUID string, opts ...ClientOption) (*UnstarDashboardByUIDOK, error) {
+	params := NewUnstarDashboardByUIDParams().WithDashboardUID(dashboardUID)
+	return a.UnstarDashboardByUIDWithParams(params, opts...)
+}
+
+func (a *Client) UnstarDashboardByUIDWithParams(params *UnstarDashboardByUIDParams, opts ...ClientOption) (*UnstarDashboardByUIDOK, error) {
 	if params == nil {
 		params = NewUnstarDashboardByUIDParams()
 	}
@@ -621,7 +673,12 @@ func (a *Client) UnstarDashboardByUID(params *UnstarDashboardByUIDParams, opts .
 /*
 UpdateSignedInUser updates signed in user
 */
-func (a *Client) UpdateSignedInUser(params *UpdateSignedInUserParams, opts ...ClientOption) (*UpdateSignedInUserOK, error) {
+func (a *Client) UpdateSignedInUser(body *models.UpdateUserCommand, opts ...ClientOption) (*UpdateSignedInUserOK, error) {
+	params := NewUpdateSignedInUserParams().WithBody(body)
+	return a.UpdateSignedInUserWithParams(params, opts...)
+}
+
+func (a *Client) UpdateSignedInUserWithParams(params *UpdateSignedInUserParams, opts ...ClientOption) (*UpdateSignedInUserOK, error) {
 	if params == nil {
 		params = NewUpdateSignedInUserParams()
 	}
@@ -662,7 +719,12 @@ UserSetUsingOrg switches user context for signed in user
 
 Switch user context to the given organization.
 */
-func (a *Client) UserSetUsingOrg(params *UserSetUsingOrgParams, opts ...ClientOption) (*UserSetUsingOrgOK, error) {
+func (a *Client) UserSetUsingOrg(orgID int64, opts ...ClientOption) (*UserSetUsingOrgOK, error) {
+	params := NewUserSetUsingOrgParams().WithOrgID(orgID)
+	return a.UserSetUsingOrgWithParams(params, opts...)
+}
+
+func (a *Client) UserSetUsingOrgWithParams(params *UserSetUsingOrgParams, opts ...ClientOption) (*UserSetUsingOrgOK, error) {
 	if params == nil {
 		params = NewUserSetUsingOrgParams()
 	}

--- a/client/snapshots/snapshots_client.go
+++ b/client/snapshots/snapshots_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new snapshots API client.
@@ -30,13 +32,17 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateDashboardSnapshot(params *CreateDashboardSnapshotParams, opts ...ClientOption) (*CreateDashboardSnapshotOK, error)
+	CreateDashboardSnapshot(body *models.CreateDashboardSnapshotCommand, opts ...ClientOption) (*CreateDashboardSnapshotOK, error)
+	CreateDashboardSnapshotWithParams(params *CreateDashboardSnapshotParams, opts ...ClientOption) (*CreateDashboardSnapshotOK, error)
 
-	DeleteDashboardSnapshot(params *DeleteDashboardSnapshotParams, opts ...ClientOption) (*DeleteDashboardSnapshotOK, error)
+	DeleteDashboardSnapshot(key string, opts ...ClientOption) (*DeleteDashboardSnapshotOK, error)
+	DeleteDashboardSnapshotWithParams(params *DeleteDashboardSnapshotParams, opts ...ClientOption) (*DeleteDashboardSnapshotOK, error)
 
-	DeleteDashboardSnapshotByDeleteKey(params *DeleteDashboardSnapshotByDeleteKeyParams, opts ...ClientOption) (*DeleteDashboardSnapshotByDeleteKeyOK, error)
+	DeleteDashboardSnapshotByDeleteKey(deleteKey string, opts ...ClientOption) (*DeleteDashboardSnapshotByDeleteKeyOK, error)
+	DeleteDashboardSnapshotByDeleteKeyWithParams(params *DeleteDashboardSnapshotByDeleteKeyParams, opts ...ClientOption) (*DeleteDashboardSnapshotByDeleteKeyOK, error)
 
-	GetDashboardSnapshot(params *GetDashboardSnapshotParams, opts ...ClientOption) (*GetDashboardSnapshotOK, error)
+	GetDashboardSnapshot(key string, opts ...ClientOption) (*GetDashboardSnapshotOK, error)
+	GetDashboardSnapshotWithParams(params *GetDashboardSnapshotParams, opts ...ClientOption) (*GetDashboardSnapshotOK, error)
 
 	GetSharingOptions(opts ...ClientOption) (*GetSharingOptionsOK, error)
 	GetSharingOptionsWithParams(params *GetSharingOptionsParams, opts ...ClientOption) (*GetSharingOptionsOK, error)
@@ -51,7 +57,12 @@ CreateDashboardSnapshot whens creating a snapshot using the API you have to prov
 
 Snapshot public mode should be enabled or authentication is required.
 */
-func (a *Client) CreateDashboardSnapshot(params *CreateDashboardSnapshotParams, opts ...ClientOption) (*CreateDashboardSnapshotOK, error) {
+func (a *Client) CreateDashboardSnapshot(body *models.CreateDashboardSnapshotCommand, opts ...ClientOption) (*CreateDashboardSnapshotOK, error) {
+	params := NewCreateDashboardSnapshotParams().WithBody(body)
+	return a.CreateDashboardSnapshotWithParams(params, opts...)
+}
+
+func (a *Client) CreateDashboardSnapshotWithParams(params *CreateDashboardSnapshotParams, opts ...ClientOption) (*CreateDashboardSnapshotOK, error) {
 	if params == nil {
 		params = NewCreateDashboardSnapshotParams()
 	}
@@ -90,7 +101,12 @@ func (a *Client) CreateDashboardSnapshot(params *CreateDashboardSnapshotParams, 
 /*
 DeleteDashboardSnapshot deletes snapshot by key
 */
-func (a *Client) DeleteDashboardSnapshot(params *DeleteDashboardSnapshotParams, opts ...ClientOption) (*DeleteDashboardSnapshotOK, error) {
+func (a *Client) DeleteDashboardSnapshot(key string, opts ...ClientOption) (*DeleteDashboardSnapshotOK, error) {
+	params := NewDeleteDashboardSnapshotParams().WithKey(key)
+	return a.DeleteDashboardSnapshotWithParams(params, opts...)
+}
+
+func (a *Client) DeleteDashboardSnapshotWithParams(params *DeleteDashboardSnapshotParams, opts ...ClientOption) (*DeleteDashboardSnapshotOK, error) {
 	if params == nil {
 		params = NewDeleteDashboardSnapshotParams()
 	}
@@ -131,7 +147,12 @@ DeleteDashboardSnapshotByDeleteKey deletes snapshot by delete key
 
 Snapshot public mode should be enabled or authentication is required.
 */
-func (a *Client) DeleteDashboardSnapshotByDeleteKey(params *DeleteDashboardSnapshotByDeleteKeyParams, opts ...ClientOption) (*DeleteDashboardSnapshotByDeleteKeyOK, error) {
+func (a *Client) DeleteDashboardSnapshotByDeleteKey(deleteKey string, opts ...ClientOption) (*DeleteDashboardSnapshotByDeleteKeyOK, error) {
+	params := NewDeleteDashboardSnapshotByDeleteKeyParams().WithDeleteKey(deleteKey)
+	return a.DeleteDashboardSnapshotByDeleteKeyWithParams(params, opts...)
+}
+
+func (a *Client) DeleteDashboardSnapshotByDeleteKeyWithParams(params *DeleteDashboardSnapshotByDeleteKeyParams, opts ...ClientOption) (*DeleteDashboardSnapshotByDeleteKeyOK, error) {
 	if params == nil {
 		params = NewDeleteDashboardSnapshotByDeleteKeyParams()
 	}
@@ -170,7 +191,12 @@ func (a *Client) DeleteDashboardSnapshotByDeleteKey(params *DeleteDashboardSnaps
 /*
 GetDashboardSnapshot gets snapshot by key
 */
-func (a *Client) GetDashboardSnapshot(params *GetDashboardSnapshotParams, opts ...ClientOption) (*GetDashboardSnapshotOK, error) {
+func (a *Client) GetDashboardSnapshot(key string, opts ...ClientOption) (*GetDashboardSnapshotOK, error) {
+	params := NewGetDashboardSnapshotParams().WithKey(key)
+	return a.GetDashboardSnapshotWithParams(params, opts...)
+}
+
+func (a *Client) GetDashboardSnapshotWithParams(params *GetDashboardSnapshotParams, opts ...ClientOption) (*GetDashboardSnapshotOK, error) {
 	if params == nil {
 		params = NewGetDashboardSnapshotParams()
 	}
@@ -210,7 +236,8 @@ func (a *Client) GetDashboardSnapshot(params *GetDashboardSnapshotParams, opts .
 GetSharingOptions gets snapshot sharing settings
 */
 func (a *Client) GetSharingOptions(opts ...ClientOption) (*GetSharingOptionsOK, error) {
-	return a.GetSharingOptionsWithParams(nil, opts...)
+	params := NewGetSharingOptionsParams()
+	return a.GetSharingOptionsWithParams(params, opts...)
 }
 
 func (a *Client) GetSharingOptionsWithParams(params *GetSharingOptionsParams, opts ...ClientOption) (*GetSharingOptionsOK, error) {
@@ -252,6 +279,7 @@ func (a *Client) GetSharingOptionsWithParams(params *GetSharingOptionsParams, op
 /*
 SearchDashboardSnapshots lists snapshots
 */
+
 func (a *Client) SearchDashboardSnapshots(params *SearchDashboardSnapshotsParams, opts ...ClientOption) (*SearchDashboardSnapshotsOK, error) {
 	if params == nil {
 		params = NewSearchDashboardSnapshotsParams()

--- a/client/sync_team_groups/sync_team_groups_client.go
+++ b/client/sync_team_groups/sync_team_groups_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new sync team groups API client.
@@ -30,11 +32,14 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddTeamGroupAPI(params *AddTeamGroupAPIParams, opts ...ClientOption) (*AddTeamGroupAPIOK, error)
+	AddTeamGroupAPI(teamID int64, body *models.TeamGroupMapping, opts ...ClientOption) (*AddTeamGroupAPIOK, error)
+	AddTeamGroupAPIWithParams(params *AddTeamGroupAPIParams, opts ...ClientOption) (*AddTeamGroupAPIOK, error)
 
-	GetTeamGroupsAPI(params *GetTeamGroupsAPIParams, opts ...ClientOption) (*GetTeamGroupsAPIOK, error)
+	GetTeamGroupsAPI(teamID int64, opts ...ClientOption) (*GetTeamGroupsAPIOK, error)
+	GetTeamGroupsAPIWithParams(params *GetTeamGroupsAPIParams, opts ...ClientOption) (*GetTeamGroupsAPIOK, error)
 
-	RemoveTeamGroupAPI(params *RemoveTeamGroupAPIParams, opts ...ClientOption) (*RemoveTeamGroupAPIOK, error)
+	RemoveTeamGroupAPI(teamID int64, groupID string, opts ...ClientOption) (*RemoveTeamGroupAPIOK, error)
+	RemoveTeamGroupAPIWithParams(params *RemoveTeamGroupAPIParams, opts ...ClientOption) (*RemoveTeamGroupAPIOK, error)
 
 	RemoveTeamGroupAPIQuery(params *RemoveTeamGroupAPIQueryParams, opts ...ClientOption) (*RemoveTeamGroupAPIQueryOK, error)
 
@@ -44,7 +49,12 @@ type ClientService interface {
 /*
 AddTeamGroupAPI adds external group
 */
-func (a *Client) AddTeamGroupAPI(params *AddTeamGroupAPIParams, opts ...ClientOption) (*AddTeamGroupAPIOK, error) {
+func (a *Client) AddTeamGroupAPI(teamID int64, body *models.TeamGroupMapping, opts ...ClientOption) (*AddTeamGroupAPIOK, error) {
+	params := NewAddTeamGroupAPIParams().WithBody(body).WithTeamID(teamID)
+	return a.AddTeamGroupAPIWithParams(params, opts...)
+}
+
+func (a *Client) AddTeamGroupAPIWithParams(params *AddTeamGroupAPIParams, opts ...ClientOption) (*AddTeamGroupAPIOK, error) {
 	if params == nil {
 		params = NewAddTeamGroupAPIParams()
 	}
@@ -83,7 +93,12 @@ func (a *Client) AddTeamGroupAPI(params *AddTeamGroupAPIParams, opts ...ClientOp
 /*
 GetTeamGroupsAPI gets external groups
 */
-func (a *Client) GetTeamGroupsAPI(params *GetTeamGroupsAPIParams, opts ...ClientOption) (*GetTeamGroupsAPIOK, error) {
+func (a *Client) GetTeamGroupsAPI(teamID int64, opts ...ClientOption) (*GetTeamGroupsAPIOK, error) {
+	params := NewGetTeamGroupsAPIParams().WithTeamID(teamID)
+	return a.GetTeamGroupsAPIWithParams(params, opts...)
+}
+
+func (a *Client) GetTeamGroupsAPIWithParams(params *GetTeamGroupsAPIParams, opts ...ClientOption) (*GetTeamGroupsAPIOK, error) {
 	if params == nil {
 		params = NewGetTeamGroupsAPIParams()
 	}
@@ -122,7 +137,12 @@ func (a *Client) GetTeamGroupsAPI(params *GetTeamGroupsAPIParams, opts ...Client
 /*
 RemoveTeamGroupAPI removes external group
 */
-func (a *Client) RemoveTeamGroupAPI(params *RemoveTeamGroupAPIParams, opts ...ClientOption) (*RemoveTeamGroupAPIOK, error) {
+func (a *Client) RemoveTeamGroupAPI(teamID int64, groupID string, opts ...ClientOption) (*RemoveTeamGroupAPIOK, error) {
+	params := NewRemoveTeamGroupAPIParams().WithGroupID(groupID).WithTeamID(teamID)
+	return a.RemoveTeamGroupAPIWithParams(params, opts...)
+}
+
+func (a *Client) RemoveTeamGroupAPIWithParams(params *RemoveTeamGroupAPIParams, opts ...ClientOption) (*RemoveTeamGroupAPIOK, error) {
 	if params == nil {
 		params = NewRemoveTeamGroupAPIParams()
 	}
@@ -161,6 +181,7 @@ func (a *Client) RemoveTeamGroupAPI(params *RemoveTeamGroupAPIParams, opts ...Cl
 /*
 RemoveTeamGroupAPIQuery removes external group
 */
+
 func (a *Client) RemoveTeamGroupAPIQuery(params *RemoveTeamGroupAPIQueryParams, opts ...ClientOption) (*RemoveTeamGroupAPIQueryOK, error) {
 	if params == nil {
 		params = NewRemoveTeamGroupAPIQueryParams()

--- a/client/teams/teams_client.go
+++ b/client/teams/teams_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new teams API client.
@@ -30,27 +32,36 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AddTeamMember(params *AddTeamMemberParams, opts ...ClientOption) (*AddTeamMemberOK, error)
+	AddTeamMember(teamID string, body *models.AddTeamMemberCommand, opts ...ClientOption) (*AddTeamMemberOK, error)
+	AddTeamMemberWithParams(params *AddTeamMemberParams, opts ...ClientOption) (*AddTeamMemberOK, error)
 
-	CreateTeam(params *CreateTeamParams, opts ...ClientOption) (*CreateTeamOK, error)
+	CreateTeam(body *models.CreateTeamCommand, opts ...ClientOption) (*CreateTeamOK, error)
+	CreateTeamWithParams(params *CreateTeamParams, opts ...ClientOption) (*CreateTeamOK, error)
 
-	DeleteTeamByID(params *DeleteTeamByIDParams, opts ...ClientOption) (*DeleteTeamByIDOK, error)
+	DeleteTeamByID(teamID string, opts ...ClientOption) (*DeleteTeamByIDOK, error)
+	DeleteTeamByIDWithParams(params *DeleteTeamByIDParams, opts ...ClientOption) (*DeleteTeamByIDOK, error)
 
-	GetTeamByID(params *GetTeamByIDParams, opts ...ClientOption) (*GetTeamByIDOK, error)
+	GetTeamByID(teamID string, opts ...ClientOption) (*GetTeamByIDOK, error)
+	GetTeamByIDWithParams(params *GetTeamByIDParams, opts ...ClientOption) (*GetTeamByIDOK, error)
 
-	GetTeamMembers(params *GetTeamMembersParams, opts ...ClientOption) (*GetTeamMembersOK, error)
+	GetTeamMembers(teamID string, opts ...ClientOption) (*GetTeamMembersOK, error)
+	GetTeamMembersWithParams(params *GetTeamMembersParams, opts ...ClientOption) (*GetTeamMembersOK, error)
 
-	GetTeamPreferences(params *GetTeamPreferencesParams, opts ...ClientOption) (*GetTeamPreferencesOK, error)
+	GetTeamPreferences(teamID string, opts ...ClientOption) (*GetTeamPreferencesOK, error)
+	GetTeamPreferencesWithParams(params *GetTeamPreferencesParams, opts ...ClientOption) (*GetTeamPreferencesOK, error)
 
-	RemoveTeamMember(params *RemoveTeamMemberParams, opts ...ClientOption) (*RemoveTeamMemberOK, error)
+	RemoveTeamMember(userID int64, teamID string, opts ...ClientOption) (*RemoveTeamMemberOK, error)
+	RemoveTeamMemberWithParams(params *RemoveTeamMemberParams, opts ...ClientOption) (*RemoveTeamMemberOK, error)
 
 	SearchTeams(params *SearchTeamsParams, opts ...ClientOption) (*SearchTeamsOK, error)
 
-	UpdateTeam(params *UpdateTeamParams, opts ...ClientOption) (*UpdateTeamOK, error)
+	UpdateTeam(teamID string, body *models.UpdateTeamCommand, opts ...ClientOption) (*UpdateTeamOK, error)
+	UpdateTeamWithParams(params *UpdateTeamParams, opts ...ClientOption) (*UpdateTeamOK, error)
 
 	UpdateTeamMember(params *UpdateTeamMemberParams, opts ...ClientOption) (*UpdateTeamMemberOK, error)
 
-	UpdateTeamPreferences(params *UpdateTeamPreferencesParams, opts ...ClientOption) (*UpdateTeamPreferencesOK, error)
+	UpdateTeamPreferences(teamID string, body *models.UpdatePrefsCmd, opts ...ClientOption) (*UpdateTeamPreferencesOK, error)
+	UpdateTeamPreferencesWithParams(params *UpdateTeamPreferencesParams, opts ...ClientOption) (*UpdateTeamPreferencesOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -58,7 +69,12 @@ type ClientService interface {
 /*
 AddTeamMember adds team member
 */
-func (a *Client) AddTeamMember(params *AddTeamMemberParams, opts ...ClientOption) (*AddTeamMemberOK, error) {
+func (a *Client) AddTeamMember(teamID string, body *models.AddTeamMemberCommand, opts ...ClientOption) (*AddTeamMemberOK, error) {
+	params := NewAddTeamMemberParams().WithBody(body).WithTeamID(teamID)
+	return a.AddTeamMemberWithParams(params, opts...)
+}
+
+func (a *Client) AddTeamMemberWithParams(params *AddTeamMemberParams, opts ...ClientOption) (*AddTeamMemberOK, error) {
 	if params == nil {
 		params = NewAddTeamMemberParams()
 	}
@@ -97,7 +113,12 @@ func (a *Client) AddTeamMember(params *AddTeamMemberParams, opts ...ClientOption
 /*
 CreateTeam adds team
 */
-func (a *Client) CreateTeam(params *CreateTeamParams, opts ...ClientOption) (*CreateTeamOK, error) {
+func (a *Client) CreateTeam(body *models.CreateTeamCommand, opts ...ClientOption) (*CreateTeamOK, error) {
+	params := NewCreateTeamParams().WithBody(body)
+	return a.CreateTeamWithParams(params, opts...)
+}
+
+func (a *Client) CreateTeamWithParams(params *CreateTeamParams, opts ...ClientOption) (*CreateTeamOK, error) {
 	if params == nil {
 		params = NewCreateTeamParams()
 	}
@@ -136,7 +157,12 @@ func (a *Client) CreateTeam(params *CreateTeamParams, opts ...ClientOption) (*Cr
 /*
 DeleteTeamByID deletes team by ID
 */
-func (a *Client) DeleteTeamByID(params *DeleteTeamByIDParams, opts ...ClientOption) (*DeleteTeamByIDOK, error) {
+func (a *Client) DeleteTeamByID(teamID string, opts ...ClientOption) (*DeleteTeamByIDOK, error) {
+	params := NewDeleteTeamByIDParams().WithTeamID(teamID)
+	return a.DeleteTeamByIDWithParams(params, opts...)
+}
+
+func (a *Client) DeleteTeamByIDWithParams(params *DeleteTeamByIDParams, opts ...ClientOption) (*DeleteTeamByIDOK, error) {
 	if params == nil {
 		params = NewDeleteTeamByIDParams()
 	}
@@ -175,7 +201,12 @@ func (a *Client) DeleteTeamByID(params *DeleteTeamByIDParams, opts ...ClientOpti
 /*
 GetTeamByID gets team by ID
 */
-func (a *Client) GetTeamByID(params *GetTeamByIDParams, opts ...ClientOption) (*GetTeamByIDOK, error) {
+func (a *Client) GetTeamByID(teamID string, opts ...ClientOption) (*GetTeamByIDOK, error) {
+	params := NewGetTeamByIDParams().WithTeamID(teamID)
+	return a.GetTeamByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetTeamByIDWithParams(params *GetTeamByIDParams, opts ...ClientOption) (*GetTeamByIDOK, error) {
 	if params == nil {
 		params = NewGetTeamByIDParams()
 	}
@@ -214,7 +245,12 @@ func (a *Client) GetTeamByID(params *GetTeamByIDParams, opts ...ClientOption) (*
 /*
 GetTeamMembers gets team members
 */
-func (a *Client) GetTeamMembers(params *GetTeamMembersParams, opts ...ClientOption) (*GetTeamMembersOK, error) {
+func (a *Client) GetTeamMembers(teamID string, opts ...ClientOption) (*GetTeamMembersOK, error) {
+	params := NewGetTeamMembersParams().WithTeamID(teamID)
+	return a.GetTeamMembersWithParams(params, opts...)
+}
+
+func (a *Client) GetTeamMembersWithParams(params *GetTeamMembersParams, opts ...ClientOption) (*GetTeamMembersOK, error) {
 	if params == nil {
 		params = NewGetTeamMembersParams()
 	}
@@ -253,7 +289,12 @@ func (a *Client) GetTeamMembers(params *GetTeamMembersParams, opts ...ClientOpti
 /*
 GetTeamPreferences gets team preferences
 */
-func (a *Client) GetTeamPreferences(params *GetTeamPreferencesParams, opts ...ClientOption) (*GetTeamPreferencesOK, error) {
+func (a *Client) GetTeamPreferences(teamID string, opts ...ClientOption) (*GetTeamPreferencesOK, error) {
+	params := NewGetTeamPreferencesParams().WithTeamID(teamID)
+	return a.GetTeamPreferencesWithParams(params, opts...)
+}
+
+func (a *Client) GetTeamPreferencesWithParams(params *GetTeamPreferencesParams, opts ...ClientOption) (*GetTeamPreferencesOK, error) {
 	if params == nil {
 		params = NewGetTeamPreferencesParams()
 	}
@@ -292,7 +333,12 @@ func (a *Client) GetTeamPreferences(params *GetTeamPreferencesParams, opts ...Cl
 /*
 RemoveTeamMember removes member from team
 */
-func (a *Client) RemoveTeamMember(params *RemoveTeamMemberParams, opts ...ClientOption) (*RemoveTeamMemberOK, error) {
+func (a *Client) RemoveTeamMember(userID int64, teamID string, opts ...ClientOption) (*RemoveTeamMemberOK, error) {
+	params := NewRemoveTeamMemberParams().WithTeamID(teamID).WithUserID(userID)
+	return a.RemoveTeamMemberWithParams(params, opts...)
+}
+
+func (a *Client) RemoveTeamMemberWithParams(params *RemoveTeamMemberParams, opts ...ClientOption) (*RemoveTeamMemberOK, error) {
 	if params == nil {
 		params = NewRemoveTeamMemberParams()
 	}
@@ -331,6 +377,7 @@ func (a *Client) RemoveTeamMember(params *RemoveTeamMemberParams, opts ...Client
 /*
 SearchTeams teams search with paging
 */
+
 func (a *Client) SearchTeams(params *SearchTeamsParams, opts ...ClientOption) (*SearchTeamsOK, error) {
 	if params == nil {
 		params = NewSearchTeamsParams()
@@ -370,7 +417,12 @@ func (a *Client) SearchTeams(params *SearchTeamsParams, opts ...ClientOption) (*
 /*
 UpdateTeam updates team
 */
-func (a *Client) UpdateTeam(params *UpdateTeamParams, opts ...ClientOption) (*UpdateTeamOK, error) {
+func (a *Client) UpdateTeam(teamID string, body *models.UpdateTeamCommand, opts ...ClientOption) (*UpdateTeamOK, error) {
+	params := NewUpdateTeamParams().WithBody(body).WithTeamID(teamID)
+	return a.UpdateTeamWithParams(params, opts...)
+}
+
+func (a *Client) UpdateTeamWithParams(params *UpdateTeamParams, opts ...ClientOption) (*UpdateTeamOK, error) {
 	if params == nil {
 		params = NewUpdateTeamParams()
 	}
@@ -409,6 +461,7 @@ func (a *Client) UpdateTeam(params *UpdateTeamParams, opts ...ClientOption) (*Up
 /*
 UpdateTeamMember updates team member
 */
+
 func (a *Client) UpdateTeamMember(params *UpdateTeamMemberParams, opts ...ClientOption) (*UpdateTeamMemberOK, error) {
 	if params == nil {
 		params = NewUpdateTeamMemberParams()
@@ -448,7 +501,12 @@ func (a *Client) UpdateTeamMember(params *UpdateTeamMemberParams, opts ...Client
 /*
 UpdateTeamPreferences updates team preferences
 */
-func (a *Client) UpdateTeamPreferences(params *UpdateTeamPreferencesParams, opts ...ClientOption) (*UpdateTeamPreferencesOK, error) {
+func (a *Client) UpdateTeamPreferences(teamID string, body *models.UpdatePrefsCmd, opts ...ClientOption) (*UpdateTeamPreferencesOK, error) {
+	params := NewUpdateTeamPreferencesParams().WithBody(body).WithTeamID(teamID)
+	return a.UpdateTeamPreferencesWithParams(params, opts...)
+}
+
+func (a *Client) UpdateTeamPreferencesWithParams(params *UpdateTeamPreferencesParams, opts ...ClientOption) (*UpdateTeamPreferencesOK, error) {
 	if params == nil {
 		params = NewUpdateTeamPreferencesParams()
 	}

--- a/client/user_preferences/user_preferences_client.go
+++ b/client/user_preferences/user_preferences_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new user preferences API client.
@@ -33,9 +35,11 @@ type ClientService interface {
 	GetUserPreferences(opts ...ClientOption) (*GetUserPreferencesOK, error)
 	GetUserPreferencesWithParams(params *GetUserPreferencesParams, opts ...ClientOption) (*GetUserPreferencesOK, error)
 
-	PatchUserPreferences(params *PatchUserPreferencesParams, opts ...ClientOption) (*PatchUserPreferencesOK, error)
+	PatchUserPreferences(body *models.PatchPrefsCmd, opts ...ClientOption) (*PatchUserPreferencesOK, error)
+	PatchUserPreferencesWithParams(params *PatchUserPreferencesParams, opts ...ClientOption) (*PatchUserPreferencesOK, error)
 
-	UpdateUserPreferences(params *UpdateUserPreferencesParams, opts ...ClientOption) (*UpdateUserPreferencesOK, error)
+	UpdateUserPreferences(body *models.UpdatePrefsCmd, opts ...ClientOption) (*UpdateUserPreferencesOK, error)
+	UpdateUserPreferencesWithParams(params *UpdateUserPreferencesParams, opts ...ClientOption) (*UpdateUserPreferencesOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -44,7 +48,8 @@ type ClientService interface {
 GetUserPreferences gets user preferences
 */
 func (a *Client) GetUserPreferences(opts ...ClientOption) (*GetUserPreferencesOK, error) {
-	return a.GetUserPreferencesWithParams(nil, opts...)
+	params := NewGetUserPreferencesParams()
+	return a.GetUserPreferencesWithParams(params, opts...)
 }
 
 func (a *Client) GetUserPreferencesWithParams(params *GetUserPreferencesParams, opts ...ClientOption) (*GetUserPreferencesOK, error) {
@@ -86,7 +91,12 @@ func (a *Client) GetUserPreferencesWithParams(params *GetUserPreferencesParams, 
 /*
 PatchUserPreferences patches user preferences
 */
-func (a *Client) PatchUserPreferences(params *PatchUserPreferencesParams, opts ...ClientOption) (*PatchUserPreferencesOK, error) {
+func (a *Client) PatchUserPreferences(body *models.PatchPrefsCmd, opts ...ClientOption) (*PatchUserPreferencesOK, error) {
+	params := NewPatchUserPreferencesParams().WithBody(body)
+	return a.PatchUserPreferencesWithParams(params, opts...)
+}
+
+func (a *Client) PatchUserPreferencesWithParams(params *PatchUserPreferencesParams, opts ...ClientOption) (*PatchUserPreferencesOK, error) {
 	if params == nil {
 		params = NewPatchUserPreferencesParams()
 	}
@@ -127,7 +137,12 @@ UpdateUserPreferences updates user preferences
 
 Omitting a key (`theme`, `homeDashboardId`, `timezone`) will cause the current value to be replaced with the system default value.
 */
-func (a *Client) UpdateUserPreferences(params *UpdateUserPreferencesParams, opts ...ClientOption) (*UpdateUserPreferencesOK, error) {
+func (a *Client) UpdateUserPreferences(body *models.UpdatePrefsCmd, opts ...ClientOption) (*UpdateUserPreferencesOK, error) {
+	params := NewUpdateUserPreferencesParams().WithBody(body)
+	return a.UpdateUserPreferencesWithParams(params, opts...)
+}
+
+func (a *Client) UpdateUserPreferencesWithParams(params *UpdateUserPreferencesParams, opts ...ClientOption) (*UpdateUserPreferencesOK, error) {
 	if params == nil {
 		params = NewUpdateUserPreferencesParams()
 	}

--- a/client/users/users_client.go
+++ b/client/users/users_client.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // New creates a new users API client.
@@ -30,20 +32,25 @@ type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetUserByID(params *GetUserByIDParams, opts ...ClientOption) (*GetUserByIDOK, error)
+	GetUserByID(userID int64, opts ...ClientOption) (*GetUserByIDOK, error)
+	GetUserByIDWithParams(params *GetUserByIDParams, opts ...ClientOption) (*GetUserByIDOK, error)
 
-	GetUserByLoginOrEmail(params *GetUserByLoginOrEmailParams, opts ...ClientOption) (*GetUserByLoginOrEmailOK, error)
+	GetUserByLoginOrEmail(loginOrEmail string, opts ...ClientOption) (*GetUserByLoginOrEmailOK, error)
+	GetUserByLoginOrEmailWithParams(params *GetUserByLoginOrEmailParams, opts ...ClientOption) (*GetUserByLoginOrEmailOK, error)
 
-	GetUserOrgList(params *GetUserOrgListParams, opts ...ClientOption) (*GetUserOrgListOK, error)
+	GetUserOrgList(userID int64, opts ...ClientOption) (*GetUserOrgListOK, error)
+	GetUserOrgListWithParams(params *GetUserOrgListParams, opts ...ClientOption) (*GetUserOrgListOK, error)
 
-	GetUserTeams(params *GetUserTeamsParams, opts ...ClientOption) (*GetUserTeamsOK, error)
+	GetUserTeams(userID int64, opts ...ClientOption) (*GetUserTeamsOK, error)
+	GetUserTeamsWithParams(params *GetUserTeamsParams, opts ...ClientOption) (*GetUserTeamsOK, error)
 
 	SearchUsers(params *SearchUsersParams, opts ...ClientOption) (*SearchUsersOK, error)
 
 	SearchUsersWithPaging(opts ...ClientOption) (*SearchUsersWithPagingOK, error)
 	SearchUsersWithPagingWithParams(params *SearchUsersWithPagingParams, opts ...ClientOption) (*SearchUsersWithPagingOK, error)
 
-	UpdateUser(params *UpdateUserParams, opts ...ClientOption) (*UpdateUserOK, error)
+	UpdateUser(userID int64, body *models.UpdateUserCommand, opts ...ClientOption) (*UpdateUserOK, error)
+	UpdateUserWithParams(params *UpdateUserParams, opts ...ClientOption) (*UpdateUserOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -51,7 +58,12 @@ type ClientService interface {
 /*
 GetUserByID gets user by id
 */
-func (a *Client) GetUserByID(params *GetUserByIDParams, opts ...ClientOption) (*GetUserByIDOK, error) {
+func (a *Client) GetUserByID(userID int64, opts ...ClientOption) (*GetUserByIDOK, error) {
+	params := NewGetUserByIDParams().WithUserID(userID)
+	return a.GetUserByIDWithParams(params, opts...)
+}
+
+func (a *Client) GetUserByIDWithParams(params *GetUserByIDParams, opts ...ClientOption) (*GetUserByIDOK, error) {
 	if params == nil {
 		params = NewGetUserByIDParams()
 	}
@@ -90,7 +102,12 @@ func (a *Client) GetUserByID(params *GetUserByIDParams, opts ...ClientOption) (*
 /*
 GetUserByLoginOrEmail gets user by login or email
 */
-func (a *Client) GetUserByLoginOrEmail(params *GetUserByLoginOrEmailParams, opts ...ClientOption) (*GetUserByLoginOrEmailOK, error) {
+func (a *Client) GetUserByLoginOrEmail(loginOrEmail string, opts ...ClientOption) (*GetUserByLoginOrEmailOK, error) {
+	params := NewGetUserByLoginOrEmailParams().WithLoginOrEmail(loginOrEmail)
+	return a.GetUserByLoginOrEmailWithParams(params, opts...)
+}
+
+func (a *Client) GetUserByLoginOrEmailWithParams(params *GetUserByLoginOrEmailParams, opts ...ClientOption) (*GetUserByLoginOrEmailOK, error) {
 	if params == nil {
 		params = NewGetUserByLoginOrEmailParams()
 	}
@@ -131,7 +148,12 @@ GetUserOrgList gets organizations for user
 
 Get organizations for user identified by id.
 */
-func (a *Client) GetUserOrgList(params *GetUserOrgListParams, opts ...ClientOption) (*GetUserOrgListOK, error) {
+func (a *Client) GetUserOrgList(userID int64, opts ...ClientOption) (*GetUserOrgListOK, error) {
+	params := NewGetUserOrgListParams().WithUserID(userID)
+	return a.GetUserOrgListWithParams(params, opts...)
+}
+
+func (a *Client) GetUserOrgListWithParams(params *GetUserOrgListParams, opts ...ClientOption) (*GetUserOrgListOK, error) {
 	if params == nil {
 		params = NewGetUserOrgListParams()
 	}
@@ -172,7 +194,12 @@ GetUserTeams gets teams for user
 
 Get teams for user identified by id.
 */
-func (a *Client) GetUserTeams(params *GetUserTeamsParams, opts ...ClientOption) (*GetUserTeamsOK, error) {
+func (a *Client) GetUserTeams(userID int64, opts ...ClientOption) (*GetUserTeamsOK, error) {
+	params := NewGetUserTeamsParams().WithUserID(userID)
+	return a.GetUserTeamsWithParams(params, opts...)
+}
+
+func (a *Client) GetUserTeamsWithParams(params *GetUserTeamsParams, opts ...ClientOption) (*GetUserTeamsOK, error) {
 	if params == nil {
 		params = NewGetUserTeamsParams()
 	}
@@ -213,6 +240,7 @@ SearchUsers gets users
 
 Returns all users that the authenticated user has permission to view, admin permission required.
 */
+
 func (a *Client) SearchUsers(params *SearchUsersParams, opts ...ClientOption) (*SearchUsersOK, error) {
 	if params == nil {
 		params = NewSearchUsersParams()
@@ -253,7 +281,8 @@ func (a *Client) SearchUsers(params *SearchUsersParams, opts ...ClientOption) (*
 SearchUsersWithPaging gets users with paging
 */
 func (a *Client) SearchUsersWithPaging(opts ...ClientOption) (*SearchUsersWithPagingOK, error) {
-	return a.SearchUsersWithPagingWithParams(nil, opts...)
+	params := NewSearchUsersWithPagingParams()
+	return a.SearchUsersWithPagingWithParams(params, opts...)
 }
 
 func (a *Client) SearchUsersWithPagingWithParams(params *SearchUsersWithPagingParams, opts ...ClientOption) (*SearchUsersWithPagingOK, error) {
@@ -297,7 +326,12 @@ UpdateUser updates user
 
 Update the user identified by id.
 */
-func (a *Client) UpdateUser(params *UpdateUserParams, opts ...ClientOption) (*UpdateUserOK, error) {
+func (a *Client) UpdateUser(userID int64, body *models.UpdateUserCommand, opts ...ClientOption) (*UpdateUserOK, error) {
+	params := NewUpdateUserParams().WithBody(body).WithUserID(userID)
+	return a.UpdateUserWithParams(params, opts...)
+}
+
+func (a *Client) UpdateUserWithParams(params *UpdateUserParams, opts ...ClientOption) (*UpdateUserOK, error) {
 	if params == nil {
 		params = NewUpdateUserParams()
 	}

--- a/models/route.go
+++ b/models/route.go
@@ -72,10 +72,6 @@ func (m *Route) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateObjectMatchers(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateProvenance(formats); err != nil {
 		res = append(res, err)
 	}
@@ -119,23 +115,6 @@ func (m *Route) validateMatchers(formats strfmt.Registry) error {
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *Route) validateObjectMatchers(formats strfmt.Registry) error {
-	if swag.IsZero(m.ObjectMatchers) { // not required
-		return nil
-	}
-
-	if err := m.ObjectMatchers.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("object_matchers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}
@@ -198,10 +177,6 @@ func (m *Route) ContextValidate(ctx context.Context, formats strfmt.Registry) er
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateObjectMatchers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateProvenance(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -241,20 +216,6 @@ func (m *Route) contextValidateMatchers(ctx context.Context, formats strfmt.Regi
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *Route) contextValidateObjectMatchers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := m.ObjectMatchers.ContextValidate(ctx, formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("object_matchers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}

--- a/models/route_export.go
+++ b/models/route_export.go
@@ -69,10 +69,6 @@ func (m *RouteExport) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateObjectMatchers(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateRoutes(formats); err != nil {
 		res = append(res, err)
 	}
@@ -119,23 +115,6 @@ func (m *RouteExport) validateMatchers(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *RouteExport) validateObjectMatchers(formats strfmt.Registry) error {
-	if swag.IsZero(m.ObjectMatchers) { // not required
-		return nil
-	}
-
-	if err := m.ObjectMatchers.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("object_matchers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("object_matchers")
-		}
-		return err
-	}
-
-	return nil
-}
-
 func (m *RouteExport) validateRoutes(formats strfmt.Registry) error {
 	if swag.IsZero(m.Routes) { // not required
 		return nil
@@ -174,10 +153,6 @@ func (m *RouteExport) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateObjectMatchers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateRoutes(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -213,20 +188,6 @@ func (m *RouteExport) contextValidateMatchers(ctx context.Context, formats strfm
 			return ve.ValidateName("matchers")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("matchers")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *RouteExport) contextValidateObjectMatchers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := m.ObjectMatchers.ContextValidate(ctx, formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("object_matchers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce.ValidateName("object_matchers")
 		}
 		return err
 	}

--- a/templates/clientClient.gotmpl
+++ b/templates/clientClient.gotmpl
@@ -45,35 +45,43 @@ type ClientOption func(*runtime.ClientOperation)
 // ClientService is the interface for Client methods
 type ClientService interface {
 	{{ range .Operations }}
+  {{- $allParamsRequired := not .Params }}
+  {{- if eq (len .Params) 1 }}{{- $allParamsRequired = (index .Params 0).Required }}{{- end }}
+  {{- if eq (len .Params) 2 }}{{- $allParamsRequired = and (index .Params 0).Required (index .Params 1).Required }}{{- end }}
 
-  {{/* META COMMENT: If there are no required params by default, remove params as a default argument and add another function (WithParams) if users want to specify longform params */}}
-  {{ if not .Params }}
-	{{ pascalize .Name }}({{ if .HasStreamingResponse }}writer io.Writer, {{ end }}opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
-	{{ pascalize .Name }}WithParams(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
-  {{ else }}
-	{{ pascalize .Name }}(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
-  {{ end }}
+   {{- /* 
+    META COMMENT: 
+    If there are two or less params and they are all required, remove params object as a default argument and add another function (WithParams) if users want to specify longform params 
+    Param generation taken from https://github.com/go-swagger/go-swagger/blob/master/generator/templates/client/parameter.gotmpl
+  */}}
+  {{ if $allParamsRequired }}
 
-	{{ end }}
+  {{ pascalize .Name }}({{- template "operationArguments" . }}) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
+	{{ end }} {{- /* if $allParamsRequired */}}
+	{{- pascalize .Name }}{{ if $allParamsRequired }}WithParams{{ end }}(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
+
+  {{ end }} {{- /* range .Operations */}}
 
 	SetTransport(transport runtime.ClientTransport)
 }
 
 {{ range .Operations }}
+{{- $allParamsRequired := not .Params }}
+{{- if eq (len .Params) 1 }}{{- $allParamsRequired = (index .Params 0).Required }}{{- end }}
+{{- if eq (len .Params) 2 }}{{- $allParamsRequired = and (index .Params 0).Required (index .Params 1).Required }}{{- end }}
 /*
-  {{ pascalize .Name }} {{ if .Summary }}{{ pluralizeFirstWord (humanize .Summary) }}{{ if .Description }}
+{{ pascalize .Name }} {{ if .Summary }}{{ pluralizeFirstWord (humanize .Summary) }}{{ if .Description }}
 
-  {{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}{{ humanize .Name }} API{{ end }}
+{{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}{{ humanize .Name }} API{{ end }}
 */
-{{- if not .Params }}
-func (a *Client) {{ pascalize .Name }}({{ if .HasStreamingResponse }}writer io.Writer, {{ end }}opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
-  return a.{{ pascalize .Name }}WithParams(nil{{ if .HasStreamingResponse }}, writer{{ end }}, opts...)
+{{- if $allParamsRequired }}
+func (a *Client) {{ pascalize .Name }}({{- template "operationArguments" . }}) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
+  params := New{{ pascalize .Name }}Params(){{ range .Params }}.With{{ pascalize .Name }}({{ varname .Name }}){{ end }}
+  return a.{{ pascalize .Name }}WithParams(params{{ if .HasStreamingResponse }}, writer{{ end }}, opts...)
 }
-
-func (a *Client) {{ pascalize .Name }}WithParams(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
-{{- else }}
-func (a *Client) {{ pascalize .Name }}(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
 {{- end }}
+
+func (a *Client) {{ pascalize .Name }}{{ if $allParamsRequired }}WithParams{{ end }}(params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
   if params == nil {
     params = New{{ pascalize .Name }}Params()
   }

--- a/templates/operationArguments.gotmpl
+++ b/templates/operationArguments.gotmpl
@@ -1,0 +1,29 @@
+{{- /* 
+    Param generation taken from https://github.com/go-swagger/go-swagger/blob/master/generator/templates/client/parameter.gotmpl
+    Only meant to be used for max 2 params
+    If the arg is body, it will be put at the end
+*/}}
+
+{{- $arguments := "" }}
+{{- range .Params }}
+    {{- $arg := printf "%s " (varname .Name) }}
+    {{- if and (not .IsArray) (not .IsMap)  (not .HasDiscriminator) (not .IsStream) (or .IsNullable) }}
+        {{- $arg = printf "%s* " $arg }}
+    {{- end }}
+    {{- if .IsFileParam }}
+        {{- $arg = printf "%sruntime.NamedReadCloser" $arg }}
+    {{- else }}
+        {{- $arg = printf "%s%s" $arg .GoType }}
+    {{- end }}
+
+    {{- if eq "body" .Name }}
+        {{- $arguments = printf "%s%s," $arguments $arg }}
+    {{- else }}
+        {{- $arguments = printf "%s,%s" $arg $arguments }}
+    {{- end }}
+{{- end }}
+{{- if .HasStreamingResponse }}
+    {{- $arguments = printf "%swriter io.Writer," $arguments }}
+{{- end }}
+
+{{-  printf "%sopts ...ClientOption" $arguments -}}


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana-openapi-client-go/pull/39 
When an operation only has 1 or 2 params, it is much simpler for users to just pass them inline than to create a params object

When we get to three and more or if any param is optional, we can keep using the full params object

**The template have gotten slightly more complex, but trust in the code diff 😄**

Example diff:

Before:
```golang
// read
params := folders.NewGetFolderByIDParams().WithFolderID(id)
resp, err := client.Folders.GetFolderByID(params)

// update
body := &models.UpdateFolderCommand{
    Overwrite: true,
    Title: d.Get("title").(string),
}
params := folders.NewUpdateFolderParams().WithBody(body).WithFolderUID(folder.UID)
if _, err := client.Folders.UpdateFolder(params); err != nil {
    return err
}
```

Now:
```golang
// read
resp, err := client.Folders.GetFolderByID(id)

// update
body := &models.UpdateFolderCommand{
    Overwrite: true,
    Title: d.Get("title").(string),
}
if _, err := client.Folders.UpdateFolder(folder.UID, body); err != nil {
    return err
}
```