### PR TITLE
Preferences: Add homeDashboardId

### DIFF
--- a/models/preferences.go
+++ b/models/preferences.go
@@ -21,6 +21,9 @@ type Preferences struct {
 	// cookie preferences
 	CookiePreferences *CookiePreferences `json:"cookiePreferences,omitempty"`
 
+	// ID for the home dashboard. This is deprecated and will be removed in a future version. Use homeDashboardUid instead.
+	HomeDashboardID int64 `json:"homeDashboardId,omitempty"`
+
 	// UID for the home dashboard
 	HomeDashboardUID string `json:"homeDashboardUID,omitempty"`
 

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -12,6 +12,13 @@ modify() {
     SCHEMA="$(echo "${SCHEMA}" | jq "${1}")"
 }
 
+# TODO: Remove on next Terraform provider version
+# This is a deprecated attribute for newer Grafana versions
+modify '.definitions.Preferences.properties.homeDashboardId = {
+  "description": "ID for the home dashboard. This is deprecated and will be removed in a future version. Use homeDashboardUid instead.",
+  "type": "integer"
+}'
+
 # Playlist models are all messed up
 # TODO: Upstream fix
 modify 'del(.definitions.Item)' # Old playlist item schema, PlaylistItem is more up to date


### PR DESCRIPTION
It's a deprecated field but it's still being used in some TF resources