### PR TITLE
feat: add way to set custom http client

### DIFF
--- a/templates/clientFacade.gotmpl
+++ b/templates/clientFacade.gotmpl
@@ -130,6 +130,8 @@ type TransportConfig struct {
     HTTPHeaders map[string]string
     // Debug sets the optional debug mode for the transport
     Debug bool
+    // Client sets the net/http client used for the transport
+    Client *http.Client
 }
 
 // WithHost overrides the default host,
@@ -193,6 +195,13 @@ func (c *{{pascalize .Name}}) WithRetries(numRetries int, retryTimeout time.Dura
 	return c
 }
 
+// WithHTTPClient sets the used net/http client and returns the API client
+func (c *{{pascalize .Name}}) WithHTTPClient(client *http.Client) *{{pascalize .Name}} {
+	c.cfg.Client = client
+	c.SetTransport(newTransportWithConfig(c.cfg))
+	return c
+}
+
 func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
 	httpTransport := http.DefaultTransport.(*http.Transport)
 	httpTransport.TLSClientConfig = cfg.TLSConfig
@@ -205,7 +214,7 @@ func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
     HTTPHeaders: cfg.HTTPHeaders,
 	}
 
-	tr := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)	
+	tr := httptransport.NewWithClient(cfg.Host, cfg.BasePath, cfg.Schemes,cfg.Client)	
 	tr.Transport = retryableTransport
 
 	var auth []runtime.ClientAuthInfoWriter

--- a/templates/clientFacade.gotmpl
+++ b/templates/clientFacade.gotmpl
@@ -214,7 +214,7 @@ func newTransportWithConfig(cfg *TransportConfig) *httptransport.Runtime {
     HTTPHeaders: cfg.HTTPHeaders,
 	}
 
-	tr := httptransport.NewWithClient(cfg.Host, cfg.BasePath, cfg.Schemes,cfg.Client)	
+	tr := httptransport.NewWithClient(cfg.Host, cfg.BasePath, cfg.Schemes, cfg.Client)	
 	tr.Transport = retryableTransport
 
 	var auth []runtime.ClientAuthInfoWriter


### PR DESCRIPTION
This change allows users to set a custom net/http.Client. This allows for easy customization of the roundtripper (without messing up auth) and setting a global timeout