### PR TITLE
Register grafana-openapi-client-go into the software catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana-openapi-client-go
+  title: grafana-openapi-client-go
+  annotations:
+    github.com/project-slug: grafana/grafana-openapi-client-go
+  links:
+    - title: Slack Channel
+      url: https://raintank-corp.slack.com/archives/C018SLDD5MW
+  description: |
+    Grafana OpenAPI Client for Go
+spec:
+  type: library
+  owner: group:default/platform-monitoring
+  lifecycle: production


### PR DESCRIPTION
This PR adds the necessary files to declare this repo into the software catalog.