### PR TITLE
fix: Apply zizmor recommendations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,18 @@ on:
     branches:
       - main
       - master
-    
+
+# Set default permissions to read-only for contents
+permissions:
+  contents: read
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+          with:
+            persist-credentials: false
         - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed #v5.1.0
           with:
               go-version: 1.21
@@ -23,4 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
       - run: make golangci-lint # Using the makefile to have the same command in CI and locally


### PR DESCRIPTION
**Changes in this PR**
- Applies the recommendations from [zizmor](https://woodruffw.github.io/zizmor/) to improve CI security

**Reference**
- https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/
