### PR TITLE
fix: allow sending isDisabled=false in UpdateServiceAccountForm

### DIFF
--- a/models/update_service_account_form.go
+++ b/models/update_service_account_form.go
@@ -21,7 +21,7 @@ import (
 type UpdateServiceAccountForm struct {
 
 	// is disabled
-	IsDisabled bool `json:"isDisabled,omitempty"`
+	IsDisabled *bool `json:"isDisabled,omitempty"`
 
 	// name
 	Name string `json:"name,omitempty"`

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -28,6 +28,10 @@ modify '.paths = .paths | walk(if type == "object" and has("operationId") then .
 modify '.definitions.ReportSchedule.properties.startDate["x-nullable"] = true'
 modify '.definitions.ReportSchedule.properties.endDate["x-nullable"] = true'
 
+# UpdateServiceAccountForm.isDisabled must be nullable
+# https://github.com/grafana/grafana-operator/pull/1907
+modify '.definitions.UpdateServiceAccountForm.properties.isDisabled["x-nullable"] = true'
+
 # Remap field time_intervals of MuteTimeInterval and TimeInterval from TimeInterval (collision) to an equivalent model TimeIntervalItem.
 modify '.definitions.TimeInterval.properties.time_intervals.items["$ref"] = "#/definitions/TimeIntervalItem"'
 modify '.definitions.MuteTimeInterval.properties.time_intervals.items["$ref"] = "#/definitions/TimeIntervalItem"'


### PR DESCRIPTION
### Problem
The client couldn't disable a service account: the generated struct omitted `isDisabled` when set to `false`, so Grafana read it as unchanged.

### Fix
During schema pull it now marks `UpdateServiceAccountForm.isDisabled` as `x-nullable=true`.
After codegen the field is `*bool`, so:
* `nil`  → don't touch the flag
* `true` → disable account
* `false`→ enable account

### Notes
* This patch is required by the [service account reconciler](https://github.com/grafana/grafana-operator/issues/1469) in grafana-operator to flip `isDisabled` both ways.
