### PR TITLE
fix: Unable to send `false` as value in `PublicDashboardDTO` due to `omitempty`

### DIFF
--- a/models/public_dashboard_dto.go
+++ b/models/public_dashboard_dto.go
@@ -22,16 +22,16 @@ type PublicDashboardDTO struct {
 	AccessToken string `json:"accessToken,omitempty"`
 
 	// annotations enabled
-	AnnotationsEnabled bool `json:"annotationsEnabled,omitempty"`
+	AnnotationsEnabled *bool `json:"annotationsEnabled,omitempty"`
 
 	// is enabled
-	IsEnabled bool `json:"isEnabled,omitempty"`
+	IsEnabled *bool `json:"isEnabled,omitempty"`
 
 	// share
 	Share ShareType `json:"share,omitempty"`
 
 	// time selection enabled
-	TimeSelectionEnabled bool `json:"timeSelectionEnabled,omitempty"`
+	TimeSelectionEnabled *bool `json:"timeSelectionEnabled,omitempty"`
 
 	// uid
 	UID string `json:"uid,omitempty"`

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -32,6 +32,11 @@ modify '.definitions.ReportSchedule.properties.endDate["x-nullable"] = true'
 # https://github.com/grafana/grafana-operator/pull/1907
 modify '.definitions.UpdateServiceAccountForm.properties.isDisabled["x-nullable"] = true'
 
+# Fix: prevent fields set to 'false' from being omitted when serializing the struct
+modify '.definitions.PublicDashboardDTO.properties.isEnabled["x-nullable"] = true'
+modify '.definitions.PublicDashboardDTO.properties.annotationsEnabled["x-nullable"] = true'
+modify '.definitions.PublicDashboardDTO.properties.timeSelectionEnabled["x-nullable"] = true'
+
 # Remap field time_intervals of MuteTimeInterval and TimeInterval from TimeInterval (collision) to an equivalent model TimeIntervalItem.
 modify '.definitions.TimeInterval.properties.time_intervals.items["$ref"] = "#/definitions/TimeIntervalItem"'
 modify '.definitions.MuteTimeInterval.properties.time_intervals.items["$ref"] = "#/definitions/TimeIntervalItem"'


### PR DESCRIPTION
Changes the "empty" value from `false` to `nil`, allowing users to disable `isEnabled`, `timeSelectionEnabled`, and `annotationsEnabled`.

Before, the fields were dropped/omitted during serialization of the struct when sending `false` values.

This appears to be a general problem with go-swagger https://github.com/go-swagger/go-swagger/issues/2386