### PR TITLE
fix: cancel retry backoff sleep when request context expires

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -9,6 +9,7 @@ min-len = 5
 min-occurrences = 5
 
 [linters-settings.depguard.rules.main]
+files = ["!**/*_test.go"]
 allow = [
   "fmt", "strconv", "time", "net/http",
   "bytes", "io", "math",

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -50,7 +50,12 @@ func (t *RetryableTransport) RoundTrip(req *http.Request) (*http.Response, error
 			if retryTimeout == 0 {
 				retryTimeout = backoff(n)
 			}
-			time.Sleep(retryTimeout)
+			select {
+			case <-time.After(retryTimeout):
+			case <-req.Context().Done():
+				// Return immediately if the context has expired or is cancelled
+				return nil, req.Context().Err()
+			}
 		}
 
 		resp, err = t.Transport.RoundTrip(req)

--- a/pkg/transport/transport_test.go
+++ b/pkg/transport/transport_test.go
@@ -1,0 +1,64 @@
+package transport_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	httptransport "github.com/go-openapi/runtime/client"
+	client "github.com/grafana/grafana-openapi-client-go/client"
+)
+
+// TestRetryBackoffRespectsContextCancellation asserts that when an API operation context
+// expires, the retry backoff sleep/delay is cancelled and the call returns promptly and
+// does not attempt to make any further requests beyond the deadline.
+//
+// This test uses a shortened DefaultTimeout (100ms) so the deadline fires during the first
+// retry sleep (2s). The call should return promptly once the context expires, not continue
+// sleeping for the full backoff duration.
+func TestRetryBackoffRespectsContextCancellation(t *testing.T) {
+	// Do not run in parallel: this test temporarily mutates the package-level
+	// DefaultTimeout variable.
+	const numRetries = 2
+
+	// Create a mock server that returns 503 on every request.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	// Shorten the per-operation context deadline to 100ms - arbitrarily short.
+	// This simulates the scenario where the code would have slept through a context deadline
+	origTimeout := httptransport.DefaultTimeout
+	httptransport.DefaultTimeout = 100 * time.Millisecond
+	defer func() { httptransport.DefaultTimeout = origTimeout }()
+
+	u, _ := url.Parse(server.URL)
+	grafanaClient := client.NewHTTPClientWithConfig(nil, &client.TransportConfig{
+		Host:       u.Host,
+		BasePath:   client.DefaultBasePath,
+		Schemes:    []string{"http"},
+		NumRetries: numRetries,
+		// RetryTimeout = 0 → exponential backoff (2^n seconds). Production default.
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := grafanaClient.Health.GetHealth() // This could be any operation
+		done <- err
+	}()
+
+	// Once the context deadline (100ms) fires, the backoff sleep should be cancelled
+	// and the call should return with an error well within 1 second.
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error after context expiry, got nil")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("call did not return within 1s of context expiry — " +
+			"the retry backoff sleep is not context-aware and is blocking indefinitely")
+	}
+}


### PR DESCRIPTION
The `time.Sleep()` between retries causes the client to hang indefinitely, if the context deadline expires before Grafana returns an acceptable status code.

For example: if Grafana returns a 5xx or other error status code for a period of 30 seconds, and the number of retries configured produces a total requests+retries duration of >30 seconds, the request will never complete.

This PR replaces the sleep with a `time.After()`, and also returns immediately if the context has already expired.

Closes #136 