### PR TITLE
fix: `CacheConfigSetter.enabled/useDefaultTTL` dropped by omitempty when false

### DIFF
--- a/models/cache_config_setter.go
+++ b/models/cache_config_setter.go
@@ -22,7 +22,7 @@ type CacheConfigSetter struct {
 	DataSourceUID string `json:"dataSourceUID,omitempty"`
 
 	// enabled
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 
 	// TTL MS, or "time to live", is how long a cached item will stay in the cache before it is removed (in milliseconds)
 	TTLQueriesMs int64 `json:"ttlQueriesMs,omitempty"`
@@ -31,7 +31,7 @@ type CacheConfigSetter struct {
 	TTLResourcesMs int64 `json:"ttlResourcesMs,omitempty"`
 
 	// If UseDefaultTTL is enabled, then the TTLQueriesMS and TTLResourcesMS in this object is always sent as the default TTL located in grafana.ini
-	UseDefaultTTL bool `json:"useDefaultTTL,omitempty"`
+	UseDefaultTTL *bool `json:"useDefaultTTL,omitempty"`
 }
 
 // Validate validates this cache config setter

--- a/scripts/pull-schema.sh
+++ b/scripts/pull-schema.sh
@@ -40,6 +40,13 @@ modify '.definitions.PublicDashboardDTO.properties.isEnabled["x-nullable"] = tru
 modify '.definitions.PublicDashboardDTO.properties.annotationsEnabled["x-nullable"] = true'
 modify '.definitions.PublicDashboardDTO.properties.timeSelectionEnabled["x-nullable"] = true'
 
+# CacheConfigSetter.enabled and useDefaultTTL must be nullable, otherwise "false"
+# values are dropped by omitempty and can never be sent to disable caching or
+# override the default TTL.
+# https://github.com/grafana/grafana-operator/issues/<TODO-fill-in-issue-number>
+modify '.definitions.CacheConfigSetter.properties.enabled["x-nullable"] = true'
+modify '.definitions.CacheConfigSetter.properties.useDefaultTTL["x-nullable"] = true'
+
 # Remap field time_intervals of MuteTimeInterval and TimeInterval from TimeInterval (collision) to an equivalent model TimeIntervalItem.
 modify '.definitions.TimeInterval.properties.time_intervals.items["$ref"] = "#/definitions/TimeIntervalItem"'
 modify '.definitions.MuteTimeInterval.properties.time_intervals.items["$ref"] = "#/definitions/TimeIntervalItem"'


### PR DESCRIPTION
Similar to https://github.com/grafana/grafana-openapi-client-go/pull/135, 
Marks enabled and useDefaultTTL on CacheConfigSetter as x-nullable in the schema patch step so they generate as `*bool`. Relates to https://github.com/grafana/grafana-operator/issues/2923